### PR TITLE
Add enable_expr option

### DIFF
--- a/alfasim_sdk/models.py
+++ b/alfasim_sdk/models.py
@@ -61,7 +61,6 @@ def data_model(*, caption: str, icon: Optional[str]=None):
     """
 
     def apply(class_: type):
-        setattr(class_, 'model', attr.ib(default=None))
 
         @functools.wraps(class_)
         def wrap_class(class_: type, caption: str, icon: Optional[str]):

--- a/alfasim_sdk/types.py
+++ b/alfasim_sdk/types.py
@@ -1,20 +1,35 @@
 import numbers
-from typing import List
+from typing import Callable, List, Optional
 
 import attr
 from attr import attrib
 from attr.validators import instance_of, optional
 
 
-@attr.s
+@attr.s(kw_only=True)
 class BaseField:
     """
     Base class for all widget fields available at alfasim.
+
+    The BaseField class and all others classes that inheritance from BaseField must use kw_only=True
+    for all attributes.
+    This is due to the necessity to make enable_expr is an optional value and the
+    only way to have properties with default values mixed with required properties is with
+    key-word only arguments.
     """
     caption: str = attrib(validator=instance_of(str))
+    enable_expr: Optional[Callable] = attrib(default=None)
+
+    @enable_expr.validator
+    def check(self, attr, value):
+        if value is None:
+            return
+
+        if not callable(value):
+            raise TypeError(f'enable_expr must be a function, got a {type(value)}.')
 
 
-@attr.s
+@attr.s(kw_only=True)
 class String(BaseField):
     """
     The String represents an input that the user can provide a string text for the application.
@@ -32,7 +47,7 @@ class String(BaseField):
     value: str = attrib(validator=instance_of(str))
 
 
-@attr.s
+@attr.s(kw_only=True)
 class Enum(BaseField):
     value: List[str] = attrib()
     initial: str = attrib(validator=optional(instance_of(str)), default=None)
@@ -50,7 +65,7 @@ class Enum(BaseField):
                 raise TypeError(f"The initial condition must be within the declared values")
 
 
-@attr.s
+@attr.s(kw_only=True)
 class DataReference(BaseField):
     value = attrib()
 
@@ -60,13 +75,13 @@ class DataReference(BaseField):
             raise TypeError(f"{attr.name} must be a valid ALFASim type")
 
 
-@attr.s
+@attr.s(kw_only=True)
 class Quantity(BaseField):
     value: numbers.Real = attrib(validator=instance_of(numbers.Real))
     unit: str = attrib(validator=instance_of(str))
 
 
-@attr.s
+@attr.s(kw_only=True)
 class TableColumn(BaseField):
     id: str = attrib(validator=instance_of(str))
     value: Quantity = attrib()
@@ -81,7 +96,7 @@ class TableColumn(BaseField):
             raise TypeError(f"{attr.name} must be a Quantity, got a {type(values)}.")
 
 
-@attr.s
+@attr.s(kw_only=True)
 class Table(BaseField):
     rows: List[TableColumn] = attrib()
 
@@ -97,16 +112,16 @@ class Table(BaseField):
             raise TypeError(f"{attr.name} must be a list of TableColumn.")
 
 
-@attr.s
+@attr.s(kw_only=True)
 class Boolean(BaseField):
     value: bool = attrib(validator=instance_of(bool))
 
 
-@attr.s
+@attr.s(kw_only=True)
 class AlfaSimType:
     name = attrib(default='alfasim')
 
 
-@attr.s
+@attr.s(kw_only=True)
 class TracerType(AlfaSimType):
     type = attrib(default='tracer')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,10 +1,23 @@
 import pytest
 
 
+def test_enable_expr():
+    from alfasim_sdk.types import String
+
+    with pytest.raises(TypeError, match="enable_expr must be a function, got a <class 'str'>"):
+        String(value='', caption='', enable_expr='')
+
+    def function_definition():
+        pass
+
+    String(value='', caption='', enable_expr=None)
+    String(value='', caption='', enable_expr=function_definition)
+
+
 def test_string():
     from alfasim_sdk.types import String
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError):
         String(value='acme')
 
     with pytest.raises(TypeError, match="'value' must be <class 'str'>"):
@@ -14,11 +27,10 @@ def test_string():
 def test_enum():
     from alfasim_sdk.types import Enum
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'caption'"):
         Enum(value=['s'], initial='')
 
-    with pytest.raises(TypeError,
-        match="value must be a list, got a <class 'str'>."):
+    with pytest.raises(TypeError, match="value must be a list, got a <class 'str'>."):
         Enum(value='', caption='')
 
     with pytest.raises(TypeError, match="value must be a list of string."):
@@ -40,7 +52,7 @@ def test_data_reference():
     class Data1:
         pass
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'caption'"):
         DataReference(value='')
 
     with pytest.raises(TypeError, match="arg 1 must be a class"):
@@ -55,7 +67,7 @@ def test_data_reference():
 def test_quantity():
     from alfasim_sdk.types import Quantity
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'caption'"):
         Quantity(value='', unit='')
 
     with pytest.raises(TypeError, match="'value' must be <class 'numbers.Real'>"):
@@ -68,7 +80,7 @@ def test_quantity():
 def test_table():
     from alfasim_sdk.types import Table
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'caption'"):
         Table(rows=[])
 
     with pytest.raises(TypeError, match="rows must be a list, got a <class 'str'>."):
@@ -94,7 +106,7 @@ def test_table_column():
 def test_boolean():
     from alfasim_sdk.types import Boolean
 
-    with pytest.raises(TypeError, match="missing 1 required positional argument: 'caption'"):
+    with pytest.raises(TypeError, match="missing 1 required keyword-only argument: 'caption'"):
         Boolean(value='')
 
     with pytest.raises(TypeError, match="'value' must be <class 'bool'"):


### PR DESCRIPTION
This pull request adds the `enable_expr` option on the `BaseField`.

Although this property is being introduced on the `BaseField`, the `enable_expr` it's an _optional_ property that the user can define or not.

In order to make this property be _optional_ and at the same time be _inherited_ by all objects, was necessary to include `kw_only=True` argument on the `attrs `declaration.