### PR TITLE
Keeping the declaration order.

### DIFF
--- a/alfasim_sdk/models.py
+++ b/alfasim_sdk/models.py
@@ -72,15 +72,12 @@ def data_model(*, caption: str, icon: Optional[str]=None):
 
 
 def _wrap(caption: str, icon: Optional[str], model: Optional[type], class_: type):
-    for name in dir(class_):
-        value = getattr(class_, name)
-
+    for key, value in class_.__dict__.items():
         if isinstance(value, BaseField):
-            if name.startswith('_'):
-                continue
-                # raise error
+            if key.startswith('_'):
+                raise TypeError(f"Error defining {key}, attributes starting with '_' are not allowed")
             new_value = attr.ib(default=value)
-            setattr(class_, name, new_value)
+            setattr(class_, key, new_value)
 
     class_._alfasim_metadata = {
         'caption': caption,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,6 @@ def user_data_model():
     @data_model(icon="model.png", caption='PLUGIN DEV MODEL')
     class Model:
         valid_attribute = ValidType(caption="valid")
-        _invalid_attribute = ValidType(caption="invalid")
 
     return Model
 
@@ -28,7 +27,6 @@ def user_data_container(user_data_model):
     @container_model(model=user_data_model, icon="container.png", caption='PLUGIN DEV CONTAINER')
     class Container:
         container_valid_attribute = ValidType(caption="valid")
-        _container_invalid_attribute = ValidType(caption="invalid")
 
     return Container
 
@@ -46,9 +44,6 @@ def test_data_model(user_data_model):
     # Attributes defined from the user should be accessed by attr fields
     assert attr.fields(user_data_model).valid_attribute is not None
 
-    # Attributes with "_" at the beginning are reserved for application usage
-    assert not hasattr(attr.fields(user_data_model), '_invalid_attribute')
-
 
 def test_data_container(user_data_container):
     import attr
@@ -60,4 +55,35 @@ def test_data_container(user_data_container):
     assert user_data_container._alfasim_metadata['icon'] == 'container.png'
 
     assert attr.fields(user_data_container).container_valid_attribute is not None
-    assert not hasattr(attr.fields(user_data_container), '_container_invalid_attribute')
+
+
+def test_invalid_attribute():
+    from alfasim_sdk.models import data_model
+    from alfasim_sdk.types import BaseField
+
+    class ValidType(BaseField):
+        pass
+
+    error_msg = "Error defining _invalid_attribute, attributes starting with '_' are not allowed"
+
+    with pytest.raises(TypeError, match=error_msg):
+
+        @data_model(icon="model.png", caption='PLUGIN DEV MODEL')
+        class Model:
+            _invalid_attribute = ValidType(caption="invalid")
+
+
+def test_attribute_order():
+    from alfasim_sdk.models import data_model
+    from alfasim_sdk.types import Boolean, DataReference, TracerType, Enum, String, Quantity
+
+    @data_model(icon="", caption='')
+    class Model:
+        boolean = Boolean(value=True, caption='')
+        data_reference = DataReference(value=TracerType, caption='')
+        enum = Enum(value=['', ''], caption='')
+        string = String(value='', caption='')
+        quantity = Quantity(value=1, unit='', caption='')
+
+    expected_order = ['boolean', 'data_reference', 'enum', 'string', 'quantity']
+    assert [attr.name for attr in Model.__attrs_attrs__] == expected_order

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -69,7 +69,7 @@ def test_invalid_attribute():
     with pytest.raises(TypeError, match=error_msg):
 
         @data_model(icon="model.png", caption='PLUGIN DEV MODEL')
-        class Model:
+        class Model: # pylint: disable=unused-variable
             _invalid_attribute = ValidType(caption="invalid")
 
 


### PR DESCRIPTION
This pull request changes the usage of `dir(class_)` to  ` class_.__dict__` to keep the declaration order intact

Also, this pull request adds a check to do not allow underscore at beginning of attributes names.
