### PR TITLE
Improve support for Linux compilers

### DIFF
--- a/alfasim_sdk_api/alfasim_sdk.h
+++ b/alfasim_sdk_api/alfasim_sdk.h
@@ -2,7 +2,7 @@
 #include <alfasim_sdk_api/detail/api_pointers.h>
 #if defined(_WIN32)
 #include <alfasim_sdk_api/detail/bootstrap_win.h>
-#elif defined(unix)
+#elif defined(unix) || defined(__unix__) || defined(__unix)
 #include <alfasim_sdk_api/detail/bootstrap_linux.h>
 #else
 #error "Unknown host (Alfasim SDK will only work on Linux and Windows)"


### PR DESCRIPTION
Clang defines `unix` but GCC does not

EDEN-1807