### PR TITLE
Set dll handle to nullptr after close the shared library

### DIFF
--- a/alfasim_sdk_api/detail/bootstrap_linux.h
+++ b/alfasim_sdk_api/detail/bootstrap_linux.h
@@ -80,6 +80,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
 inline void alfasim_sdk_close(ALFAsimSDK_API* api)
 {
     dlclose(api->handle);
+    api->handle = nullptr;
 }
 
 #endif

--- a/alfasim_sdk_api/detail/bootstrap_win.h
+++ b/alfasim_sdk_api/detail/bootstrap_win.h
@@ -100,6 +100,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
 inline void alfasim_sdk_close(ALFAsimSDK_API* api)
 {
     FreeLibrary(api->handle);
+    api->handle = nullptr;
 }
 
 #endif


### PR DESCRIPTION
It can cause an access violation in a test that runs after another test
that failed and the dll handle wasn't cleaned setting nullptr