### PR TITLE
Fb asim 1167 change from liquid to oil

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 0.3.0
 -----
 
+* Adopt terminology gas-oil-water
+
 * Rename HydrodynamicModelType items from snake_case to CamelCase, a backward compatibility option is kept.
 
 0.2.0

--- a/alfasim_sdk/constants.py
+++ b/alfasim_sdk/constants.py
@@ -4,9 +4,9 @@ GAS_PHASE = "gas"
 Constant to identify the gas phase
 """
 
-LIQUID_PHASE = "liquid"
+OIL_PHASE = "oil"
 """
-Constant to identify the liquid phase
+Constant to identify the oil phase
 """
 
 WATER_PHASE = "water"
@@ -17,9 +17,9 @@ Constant to identify the water phase
 SOLID_PHASE = "solid"
 
 GAS_FIELD = "gas"
-LIQUID_FIELD = "liquid"
+OIL_FIELD = "oil"
 WATER_FIELD = "water"
-WATER_DROPLET_IN_LIQUID_FIELD = "water_in_liquid_droplet"
+WATER_DROPLET_IN_OIL_FIELD = "water_in_oil_droplet"
 DROPLET_FIELD = "droplet"
 BUBBLE_FIELD = "bubble"
 
@@ -28,9 +28,9 @@ GAS_LAYER = "gas"
 Constant to identify the gas layer
 """
 
-LIQUID_LAYER = "liquid"
+OIL_LAYER = "oil"
 """
-Constant to identify the liquid layer
+Constant to identify the oil layer
 """
 
 WATER_LAYER = "water"

--- a/alfasim_sdk/constants.py
+++ b/alfasim_sdk/constants.py
@@ -52,14 +52,14 @@ class HydrodynamicModelType(Enum):
 
     TwoFields is valid only for the slug/regime capturing
 
-    - TwoFields - 'Two-fluid, Regime Capturing (gas-liquid)':
-        Two phase (gas and liquid) with two fields (continuous gas and continuous liquid) using Regime Capturing strategy.
+    - TwoFields - 'Two-fluid, Regime Capturing (gas-oil)':
+        Two phase (gas and oil) with two fields (continuous gas and continuous oil) using Regime Capturing strategy.
 
-    - FourFields - 'Multi-field, Unit Cell (gas-liquid)':
-        Two phase (gas and liquid) with four fields (continuous gas, continuous liquid, dispersed gas bubble, and dispersed liquid droplet).
+    - FourFields - 'Multi-field, Unit Cell (gas-oil)':
+        Two phase (gas and oil) with four fields (continuous gas, continuous oil, dispersed gas bubble, and dispersed oil droplet).
 
-    - ThreeLayersGasOilWater - 'Multi-field, Unit Cell (gas-liquid-water)':
-        Three phase (gas, liquid, and water) with five fields (continuous gas, continuous liquid, continuous water, dispersed gas bubble, and dispersed liquid droplet).
+    - ThreeLayersGasOilWater - 'Multi-field, Unit Cell (gas-oil-water)':
+        Three phase (gas, oil, and water) with five fields (continuous gas, continuous oil, continuous water, dispersed gas bubble, and dispersed liquid droplet).
 
     """
 

--- a/alfasim_sdk/context.py
+++ b/alfasim_sdk/context.py
@@ -407,13 +407,13 @@ class Context:
             HydrodynamicModelInfo( [ ... ] )
 
             >>> ctx.GetPhysicsOptions().hydrodynamic_model.fields
-            ['gas', 'liquid', 'droplet', 'bubble']
+            ['gas', 'oil', 'droplet', 'bubble']
 
             >>> ctx.GetPhysicsOptions().hydrodynamic_model.layers
-            ['gas', 'liquid']
+            ['gas', 'oil']
 
             >>> ctx.GetPhysicsOptions().hydrodynamic_model.phases
-            ['gas', 'liquid']
+            ['gas', 'oil']
 
         Checkout the :func:`~alfasim_sdk.context.PhysicsOptionsInfo` section to know more about the properties available.
 

--- a/alfasim_sdk/hook_specs.py
+++ b/alfasim_sdk/hook_specs.py
@@ -144,7 +144,7 @@ def update_plugins_secondary_variables(ctx: "void*") -> "int":
             int size_E = -1;
             int liq_id = -1;
             errcode = alfasim_sdk_api.get_field_id(
-                ctx, &liquid_id, "liquid");
+                ctx, &oil_id, "oil");
             double* vel;
             VariableScope Fields_OnFaces = {
                 GridScope::FACE,
@@ -154,7 +154,7 @@ def update_plugins_secondary_variables(ctx: "void*") -> "int":
             errcode = alfasim_sdk_api.get_simulation_array(
                 ctx, &vel, (char*) "U", Fields_OnFaces, liq_id, &size_U);
             double* kinetic_energy;
-            char* name = "kinetic_energy_of_liquid";
+            char* name = "kinetic_energy_of_oil";
             int global_idx = 0;
             errcode = alfasim_sdk_api.get_plugin_variable(
                 ctx,
@@ -172,8 +172,8 @@ def update_plugins_secondary_variables(ctx: "void*") -> "int":
             return OK;
         }
 
-    In the example above the variable ``kinetic_energy_of_liquid`` was registered as a global variable, but its value is
-    obtained for `liquid field`. If this variable would be calculated to all fields then the ``global_idx`` would be
+    In the example above the variable ``kinetic_energy_of_oil`` was registered as a global variable, but its value is
+    obtained for `oil field`. If this variable would be calculated to all fields then the ``global_idx`` would be
     substituted by ``field_idx`` and it would be performed to each `field`.
     """
 
@@ -202,7 +202,7 @@ def update_plugins_secondary_variables_on_first_timestep(ctx: "void*") -> "int":
             int errcode = -1;
             int size_E = -1;
             double* kinetic_energy;
-            char* name = "kinetic_energy_of_liquid";
+            char* name = "kinetic_energy_of_oil";
             int global_idx = 0;
             errcode = alfasim_sdk_api.get_plugin_variable(
                 ctx,
@@ -245,7 +245,7 @@ def update_plugins_secondary_variables_on_tracer_solver(ctx: "void*") -> "int":
             int size_p_var = -1;
             int liq_id = -1;
             errcode = alfasim_sdk_api.get_field_id(
-                ctx, &liquid_id, "liquid");
+                ctx, &oil_id, "oil");
             double* tracer_mass_fraction;
             VariableScope global_OnCenters = {
                 GridScope::FACE,
@@ -324,21 +324,21 @@ def calculate_mass_source_term(
         {
             int liq_id = -1;
             errcode = alfasim_sdk_api.get_field_id(
-                ctx, &liquid_id, "liquid");
+                ctx, &oil_id, "oil");
             // Convertion from void* to double* and getting the
-            // array range related to liquid field
-            double* liquid_mass_source =
+            // array range related to oil field
+            double* oil_mass_source =
                 (double*) mass_source + n_control_volumes * liq_id;
-            // Make some calculations and add it to liquid_mass_source.
+            // Make some calculations and add it to oil_mass_source.
             // In this example, we add a mass source of 3.1415 kg/s to all control volumes.
 			for (int i = 0; i < n_control_volumes; ++i) {
-    			liquid_mass_source[i] = 3.1415; // [kg/s]
+    			oil_mass_source[i] = 3.1415; // [kg/s]
 			}
             return OK;
         }
 
     In the example above is shown how to manage the ``mass_source`` array to get the mass source term array related to a
-    specific field (`liquid field` in this case). Note that ``liquid_mass_source`` has size equal to ``n_control_volumes``.
+    specific field (`oil field` in this case). Note that ``oil_mass_source`` has size equal to ``n_control_volumes``.
 
     """
 
@@ -963,7 +963,7 @@ def calculate_slurry_viscosity(
 
     :returns: Return OK if successful or anything different if failed
 
-    It is expected to be changed the mu_f_layer of liquid layer(continuous liquid and dispersed solid),
+    It is expected to be changed the mu_f_layer of oil layer(continuous oil and dispersed solid),
     whose index will be available via API.
     """
 

--- a/alfasim_sdk/hook_specs_gui.py
+++ b/alfasim_sdk/hook_specs_gui.py
@@ -285,7 +285,7 @@ def alfasim_configure_layers():
                    continuous_field='plugin_continuous_field',
                ),
                UpdateLayer(
-                   name=LIQUID_LAYER,
+                   name=OIL_LAYER,
                    additional_fields=['plugin_dispersed_field'],
                ),
            ]

--- a/alfasim_sdk/types.py
+++ b/alfasim_sdk/types.py
@@ -909,7 +909,7 @@ class UpdateLayer:
 
     List of possible layers names (see :ref:`api-constants-section` for details):
      - ``GAS_LAYER``
-     - ``LIQUID_LAYER``
+     - ``OIL_LAYER``
      - ``WATER_LAYER`` (If a three phase hydrodynamic model is used)
 
     :param name: Name of the updated layer.

--- a/alfasim_sdk_api/api.h
+++ b/alfasim_sdk_api/api.h
@@ -263,7 +263,7 @@ DLL_EXPORT int get_plugin_variable(void* ctx, void** out, const char* variable_n
 
 /*!
     Gets the field ID of the given name. Althought this depends on the hydrodynamic model being
-    solved, common values include "gas", "liquid", "droplet" and "bubble". This functions supports
+    solved, common values include "gas", "oil", "droplet" and "bubble". This functions supports
     retrieve ID of field added by plugin.
 
     @param[in] ctx ALFAsim's plugins context.
@@ -274,8 +274,8 @@ DLL_EXPORT int get_plugin_variable(void* ctx, void** out, const char* variable_n
 DLL_EXPORT int get_field_id(void* ctx, int* out, const char* name);
 
 /*!
-    Gets the primary field ID of the phase with given name. For example, the "liquid" phase has
-    primary field "liquid". Different phases may have different primary fields. Use this function
+    Gets the primary field ID of the phase with given name. For example, the "oil" phase has
+    primary field "oil". Different phases may have different primary fields. Use this function
     when you need a variable from a field, but you aren't sure about the field name, but you know
     the phase name.
 
@@ -288,7 +288,7 @@ DLL_EXPORT int get_primary_field_id_of_phase(void* ctx, int* out, const char* na
 
 /*!
     Gets the phase ID of the given name. Althought this depends on the hydrodynamic model
-    being solved, common values include "gas", "liquid" and "water". This functions supports
+    being solved, common values include "gas", "oil" and "water". This functions supports
     retrieve ID of phase added by plugin.
 
     @param[in] ctx ALFAsim's plugins context.
@@ -300,7 +300,7 @@ DLL_EXPORT int get_phase_id(void* ctx, int* out, const char* name);
 
 /*!
     Gets the layer ID of the given name. Althought this depends on the hydrodynamic model
-    being solved, common values include "gas", "liquid" and "water". This functions supports
+    being solved, common values include "gas", "oil" and "water". This functions supports
     retrieve ID of layer added by plugin.
 
     @param[in] ctx ALFAsim's plugins context.

--- a/alfasim_sdk_api/common.h
+++ b/alfasim_sdk_api/common.h
@@ -112,18 +112,18 @@ enum sdk_load_error_code {
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #define FIELD_GAS "gas"
-#define FIELD_LIQUID "liquid"
+#define FIELD_OIL "oil"
 #define FIELD_WATER "water"
 #define FIELD_WATER_DROPLET_IN_LIQUID "water_in_liquid_droplet"
 #define FIELD_DROPLET "droplet"
 #define FIELD_BUBBLE "bubble"
 
 #define PHASE_GAS "gas"
-#define PHASE_LIQUID "liquid"
+#define PHASE_OIL "oil"
 #define PHASE_WATER "water"
 
 #define LAYER_GAS "gas"
-#define LAYER_LIQUID "liquid"
+#define LAYER_OIL "oil"
 #define LAYER_WATER "water"
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/alfasim_sdk_api/common.h
+++ b/alfasim_sdk_api/common.h
@@ -114,7 +114,7 @@ enum sdk_load_error_code {
 #define FIELD_GAS "gas"
 #define FIELD_OIL "oil"
 #define FIELD_WATER "water"
-#define FIELD_WATER_DROPLET_IN_LIQUID "water_in_liquid_droplet"
+#define FIELD_WATER_DROPLET_IN_OIL "water_in_oil_droplet"
 #define FIELD_DROPLET "droplet"
 #define FIELD_BUBBLE "bubble"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alfasim-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "ALFAsim API/SDK"
 authors = ["ESSS <foss@esss.co>"]
 license = "MIT"


### PR DESCRIPTION
Renaming field liquid to oil. According to the literature of this research field, liquid is commonly referred to the sum of oil and water, not the oil itself