### PR TITLE
Update breathe

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-breathe==4.13.1
+breathe==4.16.0
 sphinx-click==2.3.0


### PR DESCRIPTION
Fix build error from sphinx, while building the documentation.
```python
ModuleNotFoundError: No module named 'sphinx.ext.mathbase'
```