### PR TITLE
Restructure the documentation to segment ALFAcase and case description.

### DIFF
--- a/docs/source/alfacase/05_case_description_by_example.rst
+++ b/docs/source/alfacase/05_case_description_by_example.rst
@@ -1,7 +1,0 @@
-.. _case-description-example:
-
-CaseDescription Example
-=======================
-
-
-In progress

--- a/docs/source/alfacase/alfacase.example.rst
+++ b/docs/source/alfacase/alfacase.example.rst
@@ -1,7 +1,7 @@
 .. _alfacase-example:
 
-ALFAcase Example
-================
+Example
+=======
 
 In this section, we will walk trough the creation of a simple network, with two nodes and one pipe, to illustrate how to
 crete a project and how to interpret the definitions available on :ref:`alfacase-reference-section`.

--- a/docs/source/alfacase/alfacase.quick_start.rst
+++ b/docs/source/alfacase/alfacase.quick_start.rst
@@ -1,7 +1,7 @@
 .. _alfacase-quick-start-section:
 
-ALFAcase Quick Start
-====================
+Quick Start
+===========
 
 In this section, it is shown how to create an :program:`ALFAcase` from an existent project, with this exported project
 you can easily modify your project and reintroduce it, with the modification, back to |alfasim|.

--- a/docs/source/alfacase/alfacase.rst
+++ b/docs/source/alfacase/alfacase.rst
@@ -1,0 +1,19 @@
+*************
+ALFAcase File
+*************
+
+ALFAcase file (``.alfacase``) is a file with a textual description of a complete case in text format (YAML).
+This file allows the user to write case files directly and execute them directly using the command line.
+Being a text file in a standard and well supported format, it also allows the user to execute complex workflows by
+manipulating the files using external software or programming languages, providing flexibility and power.
+
+    .. note::
+
+        :program:`ALFAcase` is also referenced as ``ALFAsim case file``
+
+.. toctree::
+   :maxdepth: 1
+
+   alfacase.quick_start
+   alfacase.syntax
+   alfacase.example

--- a/docs/source/alfacase/alfacase.syntax.rst
+++ b/docs/source/alfacase/alfacase.syntax.rst
@@ -1,7 +1,7 @@
 .. _alfacase-syntax:
 
-ALFAcase Syntax
-===============
+Syntax
+======
 
 
 An :program:`ALFAcase` file is a text-based file that must be written following the YAML syntax, only a restricted subset of the YAML specification

--- a/docs/source/alfacase/case_description.example.rst
+++ b/docs/source/alfacase/case_description.example.rst
@@ -1,0 +1,7 @@
+.. _case-description-example:
+
+Example
+=======
+
+
+In progress

--- a/docs/source/alfacase/case_description.quick_start.rst
+++ b/docs/source/alfacase/case_description.quick_start.rst
@@ -1,7 +1,7 @@
 .. _case-description-quick-start-section:
 
-CaseDescription Quick Start
-===========================
+Quick Start
+===========
 
 
 In progress

--- a/docs/source/alfacase/case_description.rst
+++ b/docs/source/alfacase/case_description.rst
@@ -1,0 +1,12 @@
+***************
+CaseDescription
+***************
+
+The CaseDescription configuration is a way to generate a valid ``.alfacase`` file programmatically using the |SDK|
+to instantiate a :class:`CaseDescription <alfasim_sdk.CaseDescription>` object to define an ``ALFAsim`` project.
+
+.. toctree::
+   :maxdepth: 1
+
+   case_description.quick_start
+   case_description.example

--- a/docs/source/alfacase/index.rst
+++ b/docs/source/alfacase/index.rst
@@ -1,17 +1,25 @@
-ALFAcase
-========
+Text Based Input
+================
 
 The |sdk| allows the user to create or edit a project for |alfasim| application by writing the project specification
-directly in an :program:`ALFAcase` file.
+directly in an text file.
 
-An ALFAcase file (``.alfacase``) contains a textual description of a complete case in text format (YAML).
-This file allows the user to write case files directly and execute them directly using the command line.
-Being a text file in a standard and well supported format, it also allows the user to execute complex workflows by
-manipulating the files using external software or programming languages, providing flexibility and power.
+There are two possible ways to write a project:
 
-.. note::
+ALFAcase file (``.alfacase``):
+    A file with a textual description of a complete case in text format (YAML).
+    This file allows the user to write case files directly and execute them directly using the command line.
+    Being a text file in a standard and well supported format, it also allows the user to execute complex workflows by
+    manipulating the files using external software or programming languages, providing flexibility and power.
 
-    :program:`ALFAcase` is also referenced as ``ALFAsim case file``
+    .. note::
+
+        :program:`ALFAcase` is also referenced as ``ALFAsim case file``
+
+
+CaseDescription instance:
+    A class that helps to generate a valid ``.alfacase`` file programmatically using |SDK| by instantiating a
+    :class:`CaseDescription <alfasim_sdk.CaseDescription>` object to define an ``ALFAsim`` project.
 
 
 To get quick and running with |sdk| you can read the :ref:`alfacase-quick-start-section` and the
@@ -21,9 +29,8 @@ To get quick and running with |sdk| you can read the :ref:`alfacase-quick-start-
     :maxdepth: 2
     :glob:
 
-    01_alfacase_quick_start
-    02_alfacase_syntax
-    03_alfacase_example
+    alfacase
+    case_description
 
 
 After reading the quick start section and the :program:`ALFAcase` by example section,
@@ -33,6 +40,4 @@ check out these additional resources to help better understand all the elements 
     :maxdepth: 2
     :glob:
 
-    04_case_description_quick_start
-    05_case_description_by_example
     api_reference


### PR DESCRIPTION
This PR changes the hierarchy of files and, consequently, the structure of the left side menu (something I learned recently).

With this structure, I believe the sections are better visually organized


Before:
![image](https://user-images.githubusercontent.com/5083518/101348475-72e17880-386a-11eb-8215-1b2aadc287b0.png)


After:
https://alfasim-sdk--125.org.readthedocs.build/en/125/

![image](https://user-images.githubusercontent.com/5083518/101348564-99071880-386a-11eb-935e-dadaf5cf4894.png)
![image](https://user-images.githubusercontent.com/5083518/101348584-9e646300-386a-11eb-9f20-be49a3fc0625.png)
![image](https://user-images.githubusercontent.com/5083518/101348596-a4f2da80-386a-11eb-89e1-3bc00b8db683.png)
