### PR TITLE
Add tracers to initialize_state_variables_calculator signature

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ History
     - ``LinearIPR``: ``well_index``;
     - ``HeatSourceEquipment``: ``power``;
 * **Breaking Change**: Change ``OpeningCurveDescription`` (``opening_curve`` attribute) for ``Curve`` from barril.
+* **Breaking Change**: Change signature of ``HOOK_INITIALIZE_STATE_VARIABLES_CALCULATOR``.
 
 
 0.9.0 (2021-05-04)

--- a/src/alfasim_sdk/_internal/hook_specs.py
+++ b/src/alfasim_sdk/_internal/hook_specs.py
@@ -509,12 +509,14 @@ def initialize_state_variables_calculator(
     P: "void*",
     T: "void*",
     T_mix: "void*",
+    phi: "void*",
     n_control_volumes: "int",
     n_layers: "int",
+    n_tracers: "int",
 ) -> "int":
     """
     **c++ signature** : ``HOOK_INITIALIZE_STATE_VARIABLES_CALCULATOR(void* ctx, void* P, void* T, void* T_mix,
-    int n_control_volumes, int n_layers)``
+    void* phi, int n_control_volumes, int n_layers, int n_tracers)``
 
     Hook for the state variables calculator initialization (internal ``ALFAsim`` structure).
 
@@ -526,12 +528,15 @@ def initialize_state_variables_calculator(
     :param P: Pressure values array
     :param T: Temperature values array
     :param T_mix: Mixture temperature values array
+    :param phi: Tracer mass fraction values array
     :param n_control_volumes: Number of control volumes
     :param n_layers: Number of layers
+    :param n_tracers: Number of tracers in the system
     :returns: Return OK if successful or anything different if failed
 
     The ``P`` and ``T_mix`` have size equal to ``n_control_volumes``. However, ``T`` has values contiguous in memory
-    and its dimensions are given by ``n_layers`` and ``n_control_volumes``
+    and its dimensions are given by ``n_layers`` and ``n_control_volumes``. Finally, ``phi`` dimensions are given by
+    ``n_tracers`` and ``n_control_volumes``.
 
     Example of usage:
 
@@ -540,7 +545,7 @@ def initialize_state_variables_calculator(
         :emphasize-lines: 1
 
         HOOK_INITIALIZE_STATE_VARIABLES_CALCULATOR(
-            ctx, P, T, T_mix, n_control_volumes, n_layers)
+            ctx, P, T, T_mix, phi, n_control_volumes, n_layers, n_tracers)
         {
             // getting plugin internal data
             int errcode = -1;

--- a/src/alfasim_sdk/alfasim_sdk_api/common.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/common.h
@@ -79,7 +79,9 @@ enum StateVariable {
     DRHO_DT, /*!< Partial derivative of density in relation to temperature*/
     H, /*!< Enthalpy*/
     K, /*!< Thermal Conductivity*/
-    SIGMA /*!< Interfacial tension*/
+    SIGMA, /*!< Interfacial tension*/
+    RS, /*!< gas mass fraction w.r.t. to hydrocarbon system*/
+    RSW /*!< vapor mass fraction w.r.t. to gas system*/
 };
 
 /*!


### PR DESCRIPTION
This information may be used by plugins, it's a prototype implementation.

### NOTE: This is a work in progress prototype. Only to initialize discussions.