### PR TITLE
Fix emulsion_model_plugin_id instructions

### DIFF
--- a/docs/source/alfacase_definitions/PhysicsDescription.txt
+++ b/docs/source/alfacase_definitions/PhysicsDescription.txt
@@ -14,7 +14,6 @@
             keep_former_results: bool = False
             keep_former_results: bool = False
             emulsion_model: \ :class:`EmulsionModelType <alfasim_sdk._internal.constants.EmulsionModelType>`\  = EmulsionModelType.NoModel
-            emulsion_model_plugin_id: str = ''
             flash_model: \ :class:`FlashModel <alfasim_sdk._internal.constants.FlashModel>`\  = FlashModel.HydrocarbonAndWater
             correlations_package: \ :class:`CorrelationPackageType <alfasim_sdk._internal.constants.CorrelationPackageType>`\  = CorrelationPackageType.Classical
 
@@ -31,6 +30,5 @@
             keep_former_results: boolean # optional
             keep_former_results: number # optional
             emulsion_model: \ :class:`EmulsionModelType <alfasim_sdk._internal.constants.EmulsionModelType>`\ # optional
-            emulsion_model_plugin_id: string # optional
             flash_model: \ :class:`FlashModel <alfasim_sdk._internal.constants.FlashModel>`\ # optional
             correlations_package: \ :class:`CorrelationPackageType <alfasim_sdk._internal.constants.CorrelationPackageType>`\ # optional

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -1996,9 +1996,7 @@ class PhysicsDescription:
     )
     keep_former_results: bool = attr.ib(default=False, validator=instance_of(bool))
     emulsion_model = attrib_enum(default=constants.EmulsionModelType.NoModel)
-    emulsion_model_plugin_id: str = attr.ib(
-        default="", validator=optional(instance_of(str))
-    )
+    emulsion_model_plugin_id: str = attr.ib(default="", validator=instance_of(str))
     flash_model = attrib_enum(default=constants.FlashModel.HydrocarbonAndWater)
     correlations_package = attrib_enum(
         default=constants.CorrelationPackageType.Classical

--- a/src/alfasim_sdk/_internal/alfacase/generate_schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_schema.py
@@ -245,6 +245,7 @@ def _get_attr_name(key: str, value: attr.ib) -> str:
 IGNORED_PROPERTIES = (
     "plugins",
     "table_parameters",
+    "emulsion_model_plugin_id",
 )
 
 

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -227,7 +227,6 @@ physics_description_schema = Map(
         Optional("restart_filepath"): Str(),
         Optional("keep_former_results"): Bool(),
         Optional("emulsion_model"): Enum(['no_model', 'model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012', 'brinkman1952_and_yeh1964', 'from_plugin']),
-        Optional("emulsion_model_plugin_id"): Str(),
         Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
         Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
     }
@@ -681,5 +680,5 @@ case_description_schema = Map(
         Optional("walls"): Seq(wall_description_schema),
     }
 )
-# [[[end]]] (checksum: dc34d4ca1d67717cd25e884a8649d290)
+# [[[end]]] (checksum: 41248460c8164bf2648e6a873c1af78f)
 # fmt: on

--- a/src/alfasim_sdk/_internal/hook_specs.py
+++ b/src/alfasim_sdk/_internal/hook_specs.py
@@ -1393,7 +1393,7 @@ def calculate_liq_liq_flow_pattern(
 
     .. note::
         The main input variables needed to estimate the flow pattern is available in the API function
-        :cpp:func:`get_liqliq_flow_pattern_input_variable`. Note that, the variables listed in the documentation
+        :cpp:func:`get_liq_liq_flow_pattern_input_variable`. Note that, the variables listed in the documentation
         of the cited function are related to one control volume, in which the estimation is applied.
 
     This `hook` allows the developer to implement your own flow pattern estimation algorithm for the liquid-liquid
@@ -1585,7 +1585,7 @@ def calculate_liq_liq_shear_force_per_volume(
 
     .. note::
         The main input variables needed to estimate the Shear Force is available in the API function
-        :cpp:func:`get_liqliq_shear_force_per_volume_input_variable`. Note that, the variables listed in the
+        :cpp:func:`get_liq_liq_shear_force_per_volume_input_variable`. Note that, the variables listed in the
         documentation of the cited function are related to one control volume, in which the estimation is applied.
 
     The output variable ``shear_w`` is the Wall Shear Force per unit Volume with size equal to ``2``

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PhysicsDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PhysicsDescription_.txt
@@ -14,7 +14,6 @@
             keep_former_results: bool = False
             keep_former_results: bool = False
             emulsion_model: \ :class:`EmulsionModelType <alfasim_sdk._internal.constants.EmulsionModelType>`\  = EmulsionModelType.NoModel
-            emulsion_model_plugin_id: str = ''
             flash_model: \ :class:`FlashModel <alfasim_sdk._internal.constants.FlashModel>`\  = FlashModel.HydrocarbonAndWater
             correlations_package: \ :class:`CorrelationPackageType <alfasim_sdk._internal.constants.CorrelationPackageType>`\  = CorrelationPackageType.Classical
 
@@ -31,6 +30,5 @@
             keep_former_results: boolean # optional
             keep_former_results: number # optional
             emulsion_model: \ :class:`EmulsionModelType <alfasim_sdk._internal.constants.EmulsionModelType>`\ # optional
-            emulsion_model_plugin_id: string # optional
             flash_model: \ :class:`FlashModel <alfasim_sdk._internal.constants.FlashModel>`\ # optional
             correlations_package: \ :class:`CorrelationPackageType <alfasim_sdk._internal.constants.CorrelationPackageType>`\ # optional

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -233,7 +233,6 @@ physics_description_schema = Map(
         Optional("restart_filepath"): Str(),
         Optional("keep_former_results"): Bool(),
         Optional("emulsion_model"): Enum(['no_model', 'model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012', 'brinkman1952_and_yeh1964', 'from_plugin']),
-        Optional("emulsion_model_plugin_id"): Str(),
         Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
         Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
     }


### PR DESCRIPTION
- Since the plugins are not supported in alfacase yet, the
emulsion_model_plugin_id must be ignored
- emulsion_model_plugin_id must not be optional, since it's not possible
to have None value