### PR TITLE
Update relative emulsion viscosiry hook

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ History
 * Add two new hooks to calculate solids model (for slurry viscosity and slip velocity)
 * **Breaking Change**: Change ``OpeningCurveDescription`` (``opening_curve`` attribute) for ``Curve`` from barril.
 * **Breaking Change**: Change signature of ``HOOK_INITIALIZE_STATE_VARIABLES_CALCULATOR``.
+* **Breaking Change**: Change signature of ``HOOK_CALCULATE_RELATIVE_EMULSION_VISCOSITY``.
+* Add new API function ``get_relative_emulsion_viscosity`` which is a helper function that can be used in the Hooks of Liquid-Liquid Mechanistic Model
 
 
 0.9.0 (2021-05-04)

--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -243,8 +243,8 @@ each Liquid-Liquid system plugin hooks. In the sequence, they are presented
     are implemented, the |alfasim| will show an error of configuration.
 
 .. note ::
-    Note that the all of the hooks related to the liquid-liquid system of Mechanistic Model can use same emulsion
-    viscosity model used internally by |alfasim|. It is made by helper function :cpp:func:`get_relative_emulsion_viscosity`.
+    Note that the all of the hooks related to the liquid-liquid system of Mechanistic Model can use the same emulsion
+    viscosity model used internally by |alfasim|. It can be obtained by using the helper function :cpp:func:`get_relative_emulsion_viscosity`.
     Since the liquid-liquid system is an emulsion, this helper function is important to keep the consistency between
     |alfasim| and its plugins that implement the following hooks.
 
@@ -268,8 +268,9 @@ the implementation of a relative emulsion viscosity correlation.
 .. autofunction:: alfasim_sdk._internal.hook_specs.calculate_relative_emulsion_viscosity
 
 .. warning::
-    The emulsion viscosity hook must be implemented as a simple correlation, in which all data is available as
-    parameters (Dispersed and continuous viscosities, for example). For this hook only the API functions
+    The relative emulsion viscosity hook has a limited API. Therefore the user-implemented correlations will have
+    access only to dispersed field viscosity, continuous field viscosity and volume fraction of the dispersed phase.
+    These variables are passed as arguments of the hook signature. For this hook only the API functions
     :cpp:func:`get_field_id`, :cpp:func:`get_phase_id` and :cpp:func:`get_layer_id` are available, any other API
     function will return an error code different from ``OK`` (:cpp:enum:`error_code` values) if called from this hook.
 

--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -240,7 +240,14 @@ each Liquid-Liquid system plugin hooks. In the sequence, they are presented
 
 .. warning::
     The hooks described in this section must be implemented all of them or none of them. If just part of four hooks
-    are implemented, the |Alfasim| will show an error of configuration.
+    are implemented, the |alfasim| will show an error of configuration.
+
+.. note ::
+    Note that the all of the hooks related to the liquid-liquid system of Mechanistic Model can use same emulsion
+    viscosity model used internally by |alfasim|. It is made by helper function :cpp:func:`get_relative_emulsion_viscosity`.
+    Since the liquid-liquid system is an emulsion, this helper function is important to keep the consistency between
+    |alfasim| and its plugins that implement the following hooks.
+
 
 .. autofunction:: alfasim_sdk._internal.hook_specs.calculate_liq_liq_flow_pattern
 
@@ -259,6 +266,12 @@ calculate it. In order to allow the emulsion model customization, the plugin str
 the implementation of a relative emulsion viscosity correlation.
 
 .. autofunction:: alfasim_sdk._internal.hook_specs.calculate_relative_emulsion_viscosity
+
+.. warning::
+    The emulsion viscosity hook must be implemented as a simple correlation, in which all data is available as
+    parameters (Dispersed and continuous viscosities, for example). For this hook only the API functions
+    :cpp:func:`get_field_id`, :cpp:func:`get_phase_id` and :cpp:func:`get_layer_id` are available, any other API
+    function will return an error code different from ``OK`` (:cpp:enum:`error_code` values) if called from this hook.
 
 
 User Defined Tracers

--- a/docs/source/plugins/99_1_solver_api_reference.rst
+++ b/docs/source/plugins/99_1_solver_api_reference.rst
@@ -161,6 +161,8 @@ Liquid-Liquid Mechanistic Model helpers
 
 .. doxygenfunction:: get_liq_liq_shear_force_per_volume_input_variable
 
+.. doxygenfunction:: get_relative_emulsion_viscosity
+
 .. _var_name_parsing:
 
 Variable Name Parsing

--- a/src/alfasim_sdk/_internal/hook_specs.py
+++ b/src/alfasim_sdk/_internal/hook_specs.py
@@ -1767,16 +1767,18 @@ def calculate_liq_liq_shear_force_per_volume(
 def calculate_relative_emulsion_viscosity(
     ctx: "void*",
     mu_r: "double*",
+    mu_disp: "double",
+    mu_cont: "double",
+    alpha_disp_in_layer: "double",
     disp_field_index: "int",
-    layer_index: "int",
-    n_faces: "int",
+    cont_field_index: "int",
 ) -> "int":
     """
-    **c++ signature** : ``HOOK_RELATIVE_EMULSION_VISCOSITY(void* ctx, double* mu_r, int disp_field_index, int layer_index, int n_faces)``
+    **c++ signature** : ``HOOK_RELATIVE_EMULSION_VISCOSITY(void* ctx, double* mu_r, double mu_disp, double mu_cont, double alpha_disp_in_layer)``
 
     Internal `hook` to calculate the relative emulsion viscosity in the Emulsion Model.
     This `hook` will be used in the emulsion model to calculate the apparent viscosity of the emulsion
-    (Continuous field + dispersed field).
+    (Continuous field + dispersed field = layer).
 
     The relative emulsion viscosity is defined by:
 
@@ -1793,18 +1795,10 @@ def calculate_relative_emulsion_viscosity(
     :2: :math:`\\mu_m` is the apparent viscosity
     :3: :math:`\\mu_c` is the viscosity of the continuous field
 
-    The output variable ``mu_r`` is the relative emulsion viscosity with size equal to ``n_faces`` and it
-    is dimensionless.
-    The ``disp_field_index`` is the index of the dipersed field. Since it is an emulsion dispersed field,
-    it can have values for ``oil in water`` and ``water in oil`` fields.
-    The ``layer_index`` is the index of the layer and continuous field in the layer. Since it is the index
-    of the main field of the emulsion, it can have values for ``oil``  or ``water`` layers (and/or continuous
-    fields).
-
-    .. Note::
-        It is important to know that the calculations for viscosity is performed over the faces (see
-        ``n_faces`` param). For that, any variable that should be retrieved using :cpp:func:`get_simulation_array`
-        must be use value ``Face`` in the :cpp:enum:`GridScope` param.
+    The output variable ``mu_r`` is the relative emulsion viscosity, ``mu_disp`` is the dispersed field
+    viscosity, ``mu_cont`` is the continuous field viscosity and ``alpha_disp_in_layer`` is the volume
+    fraction of dispersed field in the layer. Finally ``disp_field_index`` and ``cont_field_index`` are
+    the Dispersed and Continuous Field indexes of the emulsion, respectively.
 
     This `hook` allows the implementation of the relative emulsion viscosity correlation. Once the plugin
     installed it is important to be selected in the emulsion model configuration inside the Physics data
@@ -1812,9 +1806,12 @@ def calculate_relative_emulsion_viscosity(
 
     :param ctx: ALFAsim's plugins context
     :param mu_r: Relative emulsion viscosity
+    :param mu_disp: Dispersed field viscosity
+    :param mu_cont: Continuous field viscosity
+    :param alpha_disp_in_layer: Volume fraction of dispersed field in layer.
     :param disp_field_index: Index of the dispersed field
-    :param layer_index: Index of the Layer or Continuous Field
-    :param n_faces: Number of faces.
+    :param cont_field_index: Index of the continuous field
+
     :returns: Return OK if successful or anything different if failed
 
     Example of usage:
@@ -1823,25 +1820,27 @@ def calculate_relative_emulsion_viscosity(
         :linenos:
         :emphasize-lines: 1
 
-        HOOK_RELATIVE_EMULSION_VISCOSITY(ctx, mu_r, disp_field_index, layer_index, n_faces)
+        HOOK_RELATIVE_EMULSION_VISCOSITY(ctx, mu_r, mu_disp, mu_cont, alpha_disp_in_layer)
         {
-            const char* plugin_id = get_plugin_id()
-            errcode = alfasim_sdk_api.get_thread_id(ctx, &thread_id);
+            int water_in_oil_id = -1;
+            errcode = alfasim_sdk_api.get_field_id(ctx, &water_in_oil_id, "water in oil");
             if (errcode != OK) {
                 return errcode;
             }
-            // MyStruct is a developer defined struct to hold
-            // all important information for plugin hooks.
-            MyStruct* data = nullptr;
-            errcode = alfasim_sdk_api.get_plugin_data(ctx, (void**) &data, plugin_id, thread_id);
 
-            if (disp_field_index == data.oil_in_water_index){
+            int oil_in_water_id = -1;
+            errcode = alfasim_sdk_api.get_field_id(ctx, &oil_in_water_id, "oil in water");
+            if (errcode != OK) {
+                return errcode;
+            }
+
+            if (disp_field_index == oil_in_water_id){
                 // Calculate the relative emulsion viscosity
                 // for water dominated scenario.
                 // ComputeForWaterDominated is a function implemented
                 // by plugin developer
-                ComputeForWaterDominated(mu_r, n_faces);
-            } else if (disp_field_index == data.water_in_oil_index){
+                ComputeForWaterDominated(mu_r, mu_disp, mu_cont);
+            } else if (disp_field_index == water_in_oil_id){
                 // Calculate the relative emulsion viscosity
                 // for oil dominated scenario
                 // ComputeForOilDominated is a function implemented

--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -778,4 +778,38 @@ DLL_EXPORT int get_liq_liq_shear_force_per_volume_input_variable(
     void* ctx, double* out, const char* var_name, int phase_id
 );
 
+/*!
+    Gets the relative emulsion viscosity for liquid-liquid calculations.
+
+    During the implementation of any HOOK related to the Liquid-Liquid Mechanistic model, this
+    function provides the relative emulsion viscosity from Emulsion Model (selected through GUI).
+
+    It allows the plugin HOOKs to use the same emulsion model used internally by ALFAsim.
+
+    The definition of relative viscosity is given by the ratio between the apparent viscosity
+    (dispersed field + continuous field) and the continuous field.
+
+    @param[in] ctx ALFAsim's plugins context.
+    @param[out] out Relative Emulsion Viscosity [-].
+    @param[in] mu_disp Dispersed Field Viscosity [Pa.s].
+    @param[in] mu_cont Continuous Field Viscosity [Pa.s].
+    @param[in] alpha_disp_in_layer   Dispersed Field Volume Fraction in the layer (emulsion) [m3 of dispersed field /m3 of layer].
+    @param[in] disp_field_id  Dispersed Field Id (Can be "oil in water" or "water in oil" fields).
+    @param[in] cont_field_id  Continuous Field Id (Can be "oil" or "water" fields).
+    @return An #error_code value.
+
+    It is important to know that `disp_field_id` and `cont_field_id` must be passed because
+    the emulsion model can have different correlations for each one.
+    To use the correct Field Ids the API function #get_field_id must be used.
+*/
+DLL_EXPORT int get_relative_emulsion_viscosity(
+    void* ctx,
+    double* out,
+    double mu_disp,
+    double mu_cont,
+    double alpha_disp_in_layer,
+    int disp_field_id,
+    int cont_field_id
+);
+
 #endif

--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -790,10 +790,10 @@ DLL_EXPORT int get_liq_liq_shear_force_per_volume_input_variable(
     (dispersed field + continuous field) and the continuous field.
 
     @param[in] ctx ALFAsim's plugins context.
-    @param[out] out Relative Emulsion Viscosity [-].
+    @param[out] Relative Emulsion Viscosity [-].
     @param[in] mu_disp Dispersed Field Viscosity [Pa.s].
     @param[in] mu_cont Continuous Field Viscosity [Pa.s].
-    @param[in] alpha_disp_in_layer   Dispersed Field Volume Fraction in the layer (emulsion) [m3 of dispersed field /m3 of layer].
+    @param[in] alpha_disp_in_layer Dispersed Field Volume Fraction in the layer (emulsion) [m3 of dispersed field /m3 of layer].
     @param[in] disp_field_id  Dispersed Field Id (Can be "oil in water" or "water in oil" fields).
     @param[in] cont_field_id  Continuous Field Id (Can be "oil" or "water" fields).
     @return An #error_code value.

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
@@ -82,6 +82,7 @@ typedef int (*get_tracer_partition_coefficient_func)(void* ctx, double* out, voi
 typedef int (*get_plugin_input_data_multiplereference_selected_size_func)(void* ctx, int* indexes_size, const char* plugin_id, const char* var_name);
 typedef int (*get_input_variable_func)(void* ctx, double* out, const char* var_name, int phase_id);
 typedef int (*get_ucm_fluid_geometrical_properties_func)(void* ctx, double* S_w, double* S_i, double* H, double alpha_G, double D);
+typedef int (*get_relative_emulsion_viscosity_func)(void* ctx, double* out, double mu_disp, double mu_cont, double alpha_disp_in_layer, int disp_field_id, int cont_field_id);
 
 struct ALFAsimSDK_API {
 #if defined(_WIN32)
@@ -142,6 +143,8 @@ struct ALFAsimSDK_API {
     get_input_variable_func get_liquid_effective_viscosity_input_variable;
     get_input_variable_func get_gas_liq_surface_tension_input_variable;
     get_input_variable_func get_liq_liq_shear_force_per_volume_input_variable;
+
+    get_relative_emulsion_viscosity_func get_relative_emulsion_viscosity;
 
 };
 

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
@@ -85,6 +85,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_liquid_effective_viscosity_input_variable = (get_input_variable_func)dlsym(api->handle, "get_liquid_effective_viscosity_input_variable");
     api->get_gas_liq_surface_tension_input_variable = (get_input_variable_func)dlsym(api->handle, "get_gas_liq_surface_tension_input_variable");
     api->get_liq_liq_shear_force_per_volume_input_variable = (get_input_variable_func)dlsym(api->handle, "get_liq_liq_shear_force_per_volume_input_variable");
+    api->get_relative_emulsion_viscosity = (get_relative_emulsion_viscosity_func)dlsym(api->handle, "get_relative_emulsion_viscosity");
 
     return SDK_OK;
 }

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
@@ -109,6 +109,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_liquid_effective_viscosity_input_variable = (get_input_variable_func)GetProcAddress(api->handle, "get_liquid_effective_viscosity_input_variable");
     api->get_gas_liq_surface_tension_input_variable = (get_input_variable_func)GetProcAddress(api->handle, "get_gas_liq_surface_tension_input_variable");
     api->get_liq_liq_shear_force_per_volume_input_variable = (get_input_variable_func)GetProcAddress(api->handle, "get_liq_liq_shear_force_per_volume_input_variable");
+    api->get_relative_emulsion_viscosity = (get_relative_emulsion_viscosity_func)GetProcAddress(api->handle, "get_relative_emulsion_viscosity");
 
     return SDK_OK;
 }


### PR DESCRIPTION
Since it is supposed to implement a correlation, now this hook receives double instead of an array of doubles.