### PR TITLE
Pin docutils to avoid breaking the docs build with circular include WARNING

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ pydata-sphinx-theme
 sphinx-inline-tabs
 sphinx-copybutton
 sphinx_togglebutton
+docutils==0.16


### PR DESCRIPTION
The reported WARNINGs (60+ occurrences of the "same" issue) started occurring after docutils was updated. The WARNING message does not seem to be True though, but we didn't spend that much time investigating it further.

For now, we are pinning the docutils version until we can find out what is going on.

The WARNING is too big to paste here, to reproduce it just remove the pin and build the docs (locally or in github build). Or look [here](https://readthedocs.org/projects/alfasim-sdk/builds/14924217/)
