### PR TITLE
Update pre commit config to use python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ exclude: |
         ^tests/alfacase/test_generate_case_description_docstring/|
         ^tests/alfacase/test_generate_list_of_units/
     )
+default_language_version:
+    python: python3.7
 repos:
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.7.1


### PR DESCRIPTION
Update python version used by pre-commit.
Same as: https://github.com/ESSS/qmxgraph/pull/123

In qmx some tests failed due this and the problem was detected before merging, here all tests passed.
@nicoddemus, do you have any idea why?