### PR TITLE
fb-ASIM-4887 -> Refactor PH table model

### DIFF
--- a/docs/source/alfacase/api_reference.rst
+++ b/docs/source/alfacase/api_reference.rst
@@ -57,7 +57,9 @@ PVTs
 
 .. autoclass:: alfasim_sdk.PvtModelCorrelationDescription()
 
-.. autoclass:: alfasim_sdk.PvtModelTableParametersDescription()
+.. autoclass:: alfasim_sdk.PvtModelPtTableParametersDescription()
+
+.. autoclass:: alfasim_sdk.PvtModelPhTableParametersDescription()
 
 
 PVT Combined

--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -134,6 +134,9 @@ from alfasim_sdk._internal.alfacase.case_description import (
     PvtModelTableParametersDescription,
 )
 from alfasim_sdk._internal.alfacase.case_description import (
+    PhPvtModelTableParametersDescription,
+)
+from alfasim_sdk._internal.alfacase.case_description import (
     ReferencedPressureContainerDescription,
 )
 from alfasim_sdk._internal.alfacase.case_description import (
@@ -265,7 +268,6 @@ from alfasim_sdk._internal.constants import PipeThermalModelType
 from alfasim_sdk._internal.constants import PipeThermalPositionInput
 from alfasim_sdk._internal.constants import PumpType
 from alfasim_sdk._internal.constants import PVTCompositionalViscosityModel
-from alfasim_sdk._internal.constants import PVTTableType
 from alfasim_sdk._internal.constants import SeparatorGeometryType
 from alfasim_sdk._internal.constants import SimulationModeType
 from alfasim_sdk._internal.constants import SimulationRegimeType
@@ -440,7 +442,6 @@ __all__ = [
     "OutputAttachmentLocation",
     "OverallPipeTrendDescription",
     "PVTCompositionalViscosityModel",
-    "PVTTableType",
     "PackerDescription",
     "PhysicsDescription",
     "PigEquipmentDescription",
@@ -462,6 +463,7 @@ __all__ = [
     "PvtModelCompositionalDescription",
     "PvtModelCorrelationDescription",
     "PvtModelTableParametersDescription",
+    "PhPvtModelTableParametersDescription",
     "PvtModelsDescription",
     "Quantity",
     "Reference",

--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -131,10 +131,10 @@ from alfasim_sdk._internal.alfacase.case_description import (
 )
 from alfasim_sdk._internal.alfacase.case_description import PvtModelsDescription
 from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelTableParametersDescription,
+    PvtModelPtTableParametersDescription,
 )
 from alfasim_sdk._internal.alfacase.case_description import (
-    PhPvtModelTableParametersDescription,
+    PvtModelPhTableParametersDescription,
 )
 from alfasim_sdk._internal.alfacase.case_description import (
     ReferencedPressureContainerDescription,
@@ -462,8 +462,8 @@ __all__ = [
     "PvtModelCombinedDescription",
     "PvtModelCompositionalDescription",
     "PvtModelCorrelationDescription",
-    "PvtModelTableParametersDescription",
-    "PhPvtModelTableParametersDescription",
+    "PvtModelPtTableParametersDescription",
+    "PvtModelPhTableParametersDescription",
     "PvtModelsDescription",
     "Quantity",
     "Reference",

--- a/src/alfasim_sdk/_internal/alfacase/alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase.py
@@ -26,14 +26,15 @@ def _generate_alfatable_file_for_pvt_models_description(
     """
     from alfasim_sdk import generate_alfatable_file
 
-    for pvt_name, pvt_table_description in pvt_models.table_parameters.items():
+    #TODO: ASIM-4887: generate alfatable files for ph table
+    for pvt_name, pvt_table_description in pvt_models.pt_table_parameters.items():
         alfatable_file = generate_alfatable_file(
             alfacase_file=alfacase_file,
             alfatable_filename=pvt_name,
             description=pvt_table_description,
         )
         pvt_models.tables[pvt_name] = alfatable_file.name
-    pvt_models.table_parameters.clear()
+    pvt_models.pt_table_parameters.clear()
 
 
 def convert_description_to_alfacase(

--- a/src/alfasim_sdk/_internal/alfacase/alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase.py
@@ -26,7 +26,7 @@ def _generate_alfatable_file_for_pvt_models_description(
     """
     from alfasim_sdk import generate_alfatable_file
 
-    #TODO: ASIM-4887: generate alfatable files for ph table
+    #TODO: ASIM-4980: generate alfatable files for ph table
     for pvt_name, pvt_table_description in pvt_models.pt_table_parameters.items():
         alfatable_file = generate_alfatable_file(
             alfacase_file=alfacase_file,

--- a/src/alfasim_sdk/_internal/alfacase/alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase.py
@@ -26,7 +26,7 @@ def _generate_alfatable_file_for_pvt_models_description(
     """
     from alfasim_sdk import generate_alfatable_file
 
-    #TODO: ASIM-4980: generate alfatable files for ph table
+    # TODO: ASIM-4980: generate alfatable files for ph table
     for pvt_name, pvt_table_description in pvt_models.pt_table_parameters.items():
         alfatable_file = generate_alfatable_file(
             alfacase_file=alfacase_file,

--- a/src/alfasim_sdk/_internal/alfacase/alfatable.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfatable.py
@@ -29,7 +29,7 @@ def generate_alfatable_file(
 
 def load_pvt_model_table_parameters_description_from_alfatable(
     file_path: Path,
-) -> case_description.PvtModelTableParametersDescription:
+) -> case_description.PvtModelPtTableParametersDescription:
     """
     Load the content from the alfatable in the given file_path. The validation is turned off due to performance issues.
     """
@@ -64,6 +64,6 @@ def load_pvt_model_table_parameters_description_from_alfatable(
         key: Scalar(get_category_for(unit), content[key]["value"], content[key]["unit"])
         for key, unit in key_and_unit.items()
     }
-    return case_description.PvtModelTableParametersDescription(
+    return case_description.PvtModelPtTableParametersDescription(
         **table_parameter_keys_and_values, **table_parameter_keys_and_scalars
     )

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2243,10 +2243,6 @@ class PvtModelTableParametersDescription:
     number_of_phases: int = attr.ib(default=2, validator=instance_of(int))
     warn_when_outside: bool = attr.ib(default=True, validator=instance_of(bool))
 
-    table_type: Optional[str] = attr.ib(
-        default=constants.PVTTableType.PT.value, validator=optional(instance_of(str))
-    )
-
     def __attrs_post_init__(self):
         """
         Fix standard properties that have not been set in .TAB files.
@@ -2492,7 +2488,136 @@ class PvtModelTableParametersDescription:
         )
 
     @staticmethod
-    def create_constant_ph_table(
+    def create_empty():
+        """
+        Creates a dummy (empty) PVT Table parameters with no valid data.
+        """
+        return PvtModelTableParametersDescription(
+            pressure_values=np.array([0.0]),
+            temperature_values=np.array([0.0]),
+            table_variables=[],
+            variable_names=[],
+            number_of_phases=-1,
+        )
+
+    def __eq__(self, other):
+        """
+        Need to re-implement the equality operator because ndarrays don't support equality, so the attr's generated
+        __eq__ function does not work.
+        """
+        if type(self) is not type(other):
+            return False
+
+        if len(self.table_variables) != len(other.table_variables):
+            return False
+
+        for array1, array2 in zip(self.table_variables, other.table_variables):
+            if not np.array_equal(array1, array2):
+                return False
+
+        return (
+            (self.pressure_values == other.pressure_values).all()
+            and (self.temperature_values == other.temperature_values).all()
+            and self.variable_names == other.variable_names
+            and self.pressure_std == other.pressure_std
+            and self.temperature_std == other.temperature_std
+            and self.number_of_phases == other.number_of_phases
+        )
+
+
+@attr.s(slots=True, eq=False)
+class PhPvtModelTableParametersDescription:
+    """
+    :ivar pressure_values:
+        Array like of sorted pressure values (m number of entries). [Pa]
+
+    :ivar enthalpy_values:
+        Array like of sorted enthalpy values (n number of entries). [J/Kg]
+
+    :ivar table_variables:
+        List of array like values for each property such as densities, specific heats,
+        enthalpies, etc.
+
+    :ivar variable_names:
+        List of property names
+
+    .. include:: /alfacase_definitions/list_of_unit_for_temperature.txt
+    .. include:: /alfacase_definitions/list_of_unit_for_density.txt
+    .. include:: /alfacase_definitions/list_of_unit_for_pressure.txt
+    .. include:: /alfacase_definitions/list_of_unit_for_standard_volume_per_standard_volume.txt
+    .. include:: /alfacase_definitions/list_of_unit_for_dimensionless.txt
+    """
+
+    pressure_values: Numpy1DArray = attr.ib(
+        validator=numpy_array_validator(dimension=1), repr=collapse_array_repr
+    )
+    enthalpy_values: Numpy1DArray = attr.ib(
+        validator=numpy_array_validator(dimension=1), repr=collapse_array_repr
+    )
+    table_variables: List[Numpy1DArray] = attr.ib(
+        validator=numpy_array_validator(dimension=1, is_list=True),
+        repr=collapse_array_repr,
+    )
+    variable_names: List[str] = attr.ib(validator=list_of_strings)
+
+    pressure_std = attrib_scalar(default=Scalar(1, "bar"), is_optional=True)
+    temperature_std = attrib_scalar(default=Scalar(15, "degC"), is_optional=True)
+
+    gas_density_std = attrib_scalar(default=Scalar(1, "kg/m3"), is_optional=True)
+    oil_density_std = attrib_scalar(default=Scalar(800, "kg/m3"), is_optional=True)
+    water_density_std = attrib_scalar(default=Scalar(1000, "kg/m3"), is_optional=True)
+
+    gas_oil_ratio = attrib_scalar(default=Scalar(0, "sm3/sm3"), is_optional=True)  # GOR
+    gas_liquid_ratio = attrib_scalar(
+        default=Scalar(0, "sm3/sm3"), is_optional=True
+    )  # GLR
+    water_cut = attrib_scalar(default=Scalar(0, "-"), is_optional=True)  # WC
+    total_water_fraction = attrib_scalar(default=Scalar(0, "-"), is_optional=True)
+
+    label: Optional[str] = attr.ib(default=None, validator=optional(instance_of(str)))
+    number_of_phases: int = attr.ib(default=2, validator=instance_of(int))
+    warn_when_outside: bool = attr.ib(default=True, validator=instance_of(bool))
+
+    def __attrs_post_init__(self):
+        """
+        Fix standard properties that have not been set in .TAB files.
+
+        Some pvt tables do not set water related properties if it is a two-phase
+        table.
+
+        PVT Sim always set water related properties to np.nan.
+        Multiflash sometimes does not write the water related keyword.
+
+        """
+        if self.pressure_std is None:
+            self.pressure_std = Scalar(np.nan, "bar")
+        if self.temperature_std is None:
+            self.temperature_std = Scalar(np.nan, "degC")
+        if self.gas_density_std is None:
+            self.gas_density_std = Scalar(np.nan, "kg/m3")
+        if self.oil_density_std is None:
+            self.oil_density_std = Scalar(np.nan, "kg/m3")
+        if self.water_density_std is None:
+            self.water_density_std = Scalar(np.nan, "kg/m3")
+        if self.gas_oil_ratio is None:
+            self.gas_oil_ratio = Scalar(np.nan, "sm3/sm3")
+        if self.gas_liquid_ratio is None:
+            self.gas_liquid_ratio = Scalar(np.nan, "sm3/sm3")
+        if self.water_cut is None:
+            self.water_cut = Scalar(np.nan, "-")
+        if self.total_water_fraction is None:
+            self.total_water_fraction = Scalar(np.nan, "-")
+
+    @property
+    def pressure_unit(self):
+        return "Pa"
+
+    @property
+    def enthalpy_unit(self):
+        return "J/kg"
+
+    @staticmethod
+    def create_constant(
         rho_g_ref=1.0,
         rho_l_ref=1000.0,
         rho_w_ref=1000.0,
@@ -2690,9 +2815,9 @@ class PvtModelTableParametersDescription:
         data.append(temperature(p, h).flatten())
         names.append("temperature")
 
-        return PvtModelTableParametersDescription(
+        return PhPvtModelTableParametersDescription(
             pressure_values=pressure_values,
-            temperature_values=enthalpy_values,
+            enthalpy_values=enthalpy_values,
             table_variables=data,
             variable_names=names,
             pressure_std=Scalar(1e5, "Pa"),
@@ -2705,17 +2830,16 @@ class PvtModelTableParametersDescription:
             water_cut=Scalar(0, "-"),
             total_water_fraction=Scalar(0, "-"),
             number_of_phases=3 if has_water else 2,
-            table_type=constants.PVTTableType.PH.value,
         )
 
     @staticmethod
     def create_empty():
         """
-        Creates a dummy (empty) PVT Table parameters with no valid data.
+        Creates a dummy (empty) PH PVT Table parameters with no valid data.
         """
-        return PvtModelTableParametersDescription(
+        return PhPvtModelTableParametersDescription(
             pressure_values=np.array([0.0]),
-            temperature_values=np.array([0.0]),
+            enthalpy_values=np.array([0.0]),
             table_variables=[],
             variable_names=[],
             number_of_phases=-1,
@@ -2738,7 +2862,7 @@ class PvtModelTableParametersDescription:
 
         return (
             (self.pressure_values == other.pressure_values).all()
-            and (self.temperature_values == other.temperature_values).all()
+            and (self.enthalpy_values == other.enthalpy_values).all()
             and self.variable_names == other.variable_names
             and self.pressure_std == other.pressure_std
             and self.temperature_std == other.temperature_std
@@ -2782,7 +2906,7 @@ class PvtModelsDescription:
 
             >>> Path("./my_file.tab|MyPvtModel")
 
-    :ivar table_parameters:
+    :ivar pt_table_parameters:
         *INTERNAL USE ONLY*
 
         This attribute is populated when exporting a Study to a CaseDescription, and it holds a model representation
@@ -2792,6 +2916,15 @@ class PvtModelsDescription:
         where the original PVT file cannot be guaranteed to exist therefore the only reproducible way to recreate
         the PVT is trough the PvtModelTableParametersDescription.
 
+    :ivar ph_table_parameters:
+        *INTERNAL USE ONLY*
+
+        This attribute is populated when exporting a Study to a CaseDescription, and it holds a model representation
+        of a PVT originated from a (.tab / .alfatable) file.
+
+        Their usage is directly related to the export of a CaseDescription to a `.alfacase`/`.alfatable` file,
+        where the original PVT file cannot be guaranteed to exist therefore the only reproducible way to recreate
+        the PVT is trough the PhPvtModelTableParametersDescription.
 
     .. include:: /alfacase_definitions/PvtModelsDescription.txt
 
@@ -2829,7 +2962,8 @@ class PvtModelsDescription:
     correlations = attrib_dict_of(PvtModelCorrelationDescription)
     compositional = attrib_dict_of(PvtModelCompositionalDescription)
     combined = attrib_dict_of(PvtModelCombinedDescription)
-    table_parameters = attrib_dict_of(PvtModelTableParametersDescription)
+    pt_table_parameters = attrib_dict_of(PvtModelTableParametersDescription)
+    ph_table_parameters = attrib_dict_of(PhPvtModelTableParametersDescription)
 
     @staticmethod
     def get_pvt_file_and_model_name(
@@ -3038,7 +3172,8 @@ class CaseDescription:
                 self.pvt_models.correlations.keys(),
                 self.pvt_models.compositional.keys(),
                 self.pvt_models.combined.keys(),
-                self.pvt_models.table_parameters.keys(),
+                self.pvt_models.pt_table_parameters.keys(),
+                self.pvt_models.ph_table_parameters.keys(),
             )
         )
         if (
@@ -3173,7 +3308,7 @@ class CaseDescription:
         """
 
         # Update this tuple when a new PVT Model is added.
-        known_pvt_models = ("compositional", "combined", "correlations", "tables")
+        known_pvt_models = ("compositional", "combined", "correlations", "pt_table_parameters", "ph_table_parameters", "tables")
         all_fluids = [
             fluid
             for known_pvt_attr in known_pvt_models

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2845,6 +2845,18 @@ class PvtModelPhTableParametersDescription:
             number_of_phases=-1,
         )
 
+    @staticmethod
+    def dummy_parameters_dict():
+        """
+        Creates a dummy PH PVT Table parameters dict to set in the Memento.
+        """
+        return {
+            'pressure_values': np.array([0.0]),
+            'enthalpy_values': np.array([0.0]),
+            'table_variables': [],
+            'variable_names': [],
+        }
+
     def __eq__(self, other):
         """
         Need to re-implement the equality operator because ndarrays don't support equality, so the attr's generated

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -3309,7 +3309,7 @@ class CaseDescription:
         """
 
         # Update this tuple when a new PVT Model is added.
-        known_pvt_models = ("compositional", "combined", "correlations", "pt_table_parameters", "ph_table_parameters", "tables")
+        known_pvt_models = ("compositional", "combined", "correlations", "tables")
         all_fluids = [
             fluid
             for known_pvt_attr in known_pvt_models

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2191,7 +2191,7 @@ class PvtModelCombinedDescription:
 
 
 @attr.s(slots=True, eq=False)
-class PvtModelTableParametersDescription:
+class PvtModelPtTableParametersDescription:
     """
     :ivar pressure_values:
         Array like of sorted pressure values (m number of entries). [Pa]
@@ -2470,7 +2470,7 @@ class PvtModelTableParametersDescription:
                 "oil_water_surface_tension",
             ]
 
-        return PvtModelTableParametersDescription(
+        return PvtModelPtTableParametersDescription(
             pressure_values=pressure_values,
             temperature_values=temperature_values,
             table_variables=data,
@@ -2492,7 +2492,7 @@ class PvtModelTableParametersDescription:
         """
         Creates a dummy (empty) PVT Table parameters with no valid data.
         """
-        return PvtModelTableParametersDescription(
+        return PvtModelPtTableParametersDescription(
             pressure_values=np.array([0.0]),
             temperature_values=np.array([0.0]),
             table_variables=[],
@@ -2526,7 +2526,7 @@ class PvtModelTableParametersDescription:
 
 
 @attr.s(slots=True, eq=False)
-class PhPvtModelTableParametersDescription:
+class PvtModelPhTableParametersDescription:
     """
     :ivar pressure_values:
         Array like of sorted pressure values (m number of entries). [Pa]
@@ -2815,7 +2815,7 @@ class PhPvtModelTableParametersDescription:
         data.append(temperature(p, h).flatten())
         names.append("temperature")
 
-        return PhPvtModelTableParametersDescription(
+        return PvtModelPhTableParametersDescription(
             pressure_values=pressure_values,
             enthalpy_values=enthalpy_values,
             table_variables=data,
@@ -2837,7 +2837,7 @@ class PhPvtModelTableParametersDescription:
         """
         Creates a dummy (empty) PH PVT Table parameters with no valid data.
         """
-        return PhPvtModelTableParametersDescription(
+        return PvtModelPhTableParametersDescription(
             pressure_values=np.array([0.0]),
             enthalpy_values=np.array([0.0]),
             table_variables=[],
@@ -2914,7 +2914,7 @@ class PvtModelsDescription:
 
         Their usage is directly related to the export of a CaseDescription to a `.alfacase`/`.alfatable` file,
         where the original PVT file cannot be guaranteed to exist therefore the only reproducible way to recreate
-        the PVT is trough the PvtModelTableParametersDescription.
+        the PVT is trough the PvtModelPtTableParametersDescription.
 
     :ivar ph_table_parameters:
         *INTERNAL USE ONLY*
@@ -2925,7 +2925,7 @@ class PvtModelsDescription:
 
         Their usage is directly related to the export of a CaseDescription to a `.alfacase`/`.alfatable` file,
         where the original PVT file cannot be guaranteed to exist therefore the only reproducible way to recreate
-        the PVT is trough the PhPvtModelTableParametersDescription.
+        the PVT is trough the PvtModelPhTableParametersDescription.
 
     .. include:: /alfacase_definitions/PvtModelsDescription.txt
 
@@ -2963,8 +2963,8 @@ class PvtModelsDescription:
     correlations = attrib_dict_of(PvtModelCorrelationDescription)
     compositional = attrib_dict_of(PvtModelCompositionalDescription)
     combined = attrib_dict_of(PvtModelCombinedDescription)
-    pt_table_parameters = attrib_dict_of(PvtModelTableParametersDescription)
-    ph_table_parameters = attrib_dict_of(PhPvtModelTableParametersDescription)
+    pt_table_parameters = attrib_dict_of(PvtModelPtTableParametersDescription)
+    ph_table_parameters = attrib_dict_of(PvtModelPhTableParametersDescription)
 
     @staticmethod
     def get_pvt_file_and_model_name(

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2920,7 +2920,8 @@ class PvtModelsDescription:
         *INTERNAL USE ONLY*
 
         This attribute is populated when exporting a Study to a CaseDescription, and it holds a model representation
-        of a PVT originated from a (.tab / .alfatable) file.
+        of a PVT originating from a (.tab / .alfatable) file. Also, it holds values from a Pressure-Enthalpy PVT table,
+        in which temperature is one of the output/state variables.
 
         Their usage is directly related to the export of a CaseDescription to a `.alfacase`/`.alfatable` file,
         where the original PVT file cannot be guaranteed to exist therefore the only reproducible way to recreate

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2851,10 +2851,10 @@ class PvtModelPhTableParametersDescription:
         Creates a dummy PH PVT Table parameters dict to set in the Memento.
         """
         return {
-            'pressure_values': np.array([0.0]),
-            'enthalpy_values': np.array([0.0]),
-            'table_variables': [],
-            'variable_names': [],
+            "pressure_values": np.array([0.0]),
+            "enthalpy_values": np.array([0.0]),
+            "table_variables": [],
+            "variable_names": [],
         }
 
     def __eq__(self, other):

--- a/src/alfasim_sdk/_internal/alfacase/generate_schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_schema.py
@@ -270,7 +270,8 @@ def _get_attr_name(key: str, value: attr.ib) -> str:
 
 IGNORED_PROPERTIES = (
     "plugins",
-    "table_parameters",
+    "pt_table_parameters",
+    "ph_table_parameters",
     "emulsion_model_plugin_id",
 )
 

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -226,18 +226,6 @@ class PVTCompositionalViscosityModel(Enum):
     LohrenzBrayClark = "lohrenz_bray_clark"
 
 
-class PVTTableType(Enum):
-    """
-    Informs what type of PVT table to build
-
-    - PT: pressure and temperature as primary variables
-    - PH: pressure and enthalpy as primary variables
-    """
-
-    PT = "pvt_model_table"
-    PH = "pvt_model_ph_table"
-
-
 class MaterialType(Enum):
     Solid = "solid"
     Fluid = "fluid"

--- a/tests/alfacase/test_alfatable.py
+++ b/tests/alfacase/test_alfatable.py
@@ -64,7 +64,7 @@ def test_alfatable_has_flow_style_for_numpy_array(tmp_path):
     """
     )
 
-# TODO: ASIM-4887: test the export of a PH table alfacase file
+# TODO: ASIM-4980: test the export of a PH table alfacase file
 def test_alfacase_file_export(tmp_path):
     """
     Check that GenerateAlfacaseFile creates a alfatable file with the content from PvtModelsDescription.table_parameters

--- a/tests/alfacase/test_alfatable.py
+++ b/tests/alfacase/test_alfatable.py
@@ -64,6 +64,7 @@ def test_alfatable_has_flow_style_for_numpy_array(tmp_path):
     """
     )
 
+
 # TODO: ASIM-4980: test the export of a PH table alfacase file
 def test_alfacase_file_export(tmp_path):
     """

--- a/tests/alfacase/test_alfatable.py
+++ b/tests/alfacase/test_alfatable.py
@@ -5,11 +5,11 @@ import numpy as np
 from alfasim_sdk import convert_alfacase_to_description
 from alfasim_sdk import generate_alfacase_file
 from alfasim_sdk import generate_alfatable_file
-from alfasim_sdk import PvtModelTableParametersDescription
+from alfasim_sdk import PvtModelPtTableParametersDescription
 
 
 def test_alfatable_has_flow_style_for_numpy_array(tmp_path):
-    description = PvtModelTableParametersDescription(
+    description = PvtModelPtTableParametersDescription(
         pressure_values=np.array([1, 2, 3]),
         temperature_values=np.array([4, 5, 6]),
         table_variables=[
@@ -75,7 +75,7 @@ def test_alfacase_file_export(tmp_path):
     alfatable_file = tmp_path / "mycase.fluid_a_1.alfatable"
 
     pvt_model_table_parameter = {
-        "FLUID-A 1": PvtModelTableParametersDescription.create_constant()
+        "FLUID-A 1": PvtModelPtTableParametersDescription.create_constant()
     }
     from alfasim_sdk._internal.alfacase import case_description
 
@@ -98,7 +98,7 @@ def test_alfacase_file_load(tmp_path):
 
     alfacase_file = tmp_path / "mycase.alfacase"
     pvt_table_parameters_description = (
-        case_description.PvtModelTableParametersDescription.create_constant()
+        case_description.PvtModelPtTableParametersDescription.create_constant()
     )
     alfatable_file = generate_alfatable_file(
         alfacase_file=alfacase_file,

--- a/tests/alfacase/test_alfatable.py
+++ b/tests/alfacase/test_alfatable.py
@@ -61,11 +61,10 @@ def test_alfatable_has_flow_style_for_numpy_array(tmp_path):
           unit: '-'
         number_of_phases: 2
         warn_when_outside: True
-        table_type: pvt_model_table
     """
     )
 
-
+# TODO: ASIM-4887: test the export of a PH table alfacase file
 def test_alfacase_file_export(tmp_path):
     """
     Check that GenerateAlfacaseFile creates a alfatable file with the content from PvtModelsDescription.table_parameters
@@ -82,7 +81,7 @@ def test_alfacase_file_export(tmp_path):
 
     case_description = case_description.CaseDescription(
         pvt_models=case_description.PvtModelsDescription(
-            table_parameters=pvt_model_table_parameter
+            pt_table_parameters=pvt_model_table_parameter
         )
     )
 

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -291,7 +291,7 @@ def default_case(tmp_path) -> case_description.CaseDescription:
             tables={"PVT1": f"{tab_file}"},
             correlations={"PVT2": case_description.PvtModelCorrelationDescription()},
             compositional={"PVT3": case_description.PvtModelCompositionalDescription()},
-            table_parameters={
+            pt_table_parameters={
                 "PVT4": case_description.PvtModelTableParametersDescription.create_empty()
             },
         )
@@ -1430,7 +1430,8 @@ def test_check_fluid_references(default_well: case_description.WallDescription) 
         "compositional",
         "correlations",
         "default_model",
-        "table_parameters",
+        "pt_table_parameters",
+        "ph_table_parameters",
         "tables",
     }
 

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -16,7 +16,6 @@ from ..common_testing.alfasim_sdk_common_testing.case_builders import (
 )
 from alfasim_sdk import MaterialDescription
 from alfasim_sdk import NodeCellType
-from alfasim_sdk import PvtModelTableParametersDescription
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
 from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_array
@@ -47,6 +46,19 @@ from alfasim_sdk._internal.alfacase.case_description_attributes import (
 from alfasim_sdk._internal.alfacase.case_description_attributes import to_array
 from alfasim_sdk._internal.alfacase.case_description_attributes import to_curve
 
+# Note: the table parameters descriptions have the same methods, so it could
+# implement some tests for the both
+@pytest.fixture(
+    params=(
+        case_description.PvtModelTableParametersDescription,
+        case_description.PhPvtModelTableParametersDescription
+    ),
+    ids=(
+        "pt_table_description", "ph_table_description"
+    )
+)
+def table_parameters_description(request):
+    return request.param
 
 def test_physics_description_path_validator(tmp_path):
     """
@@ -294,6 +306,9 @@ def default_case(tmp_path) -> case_description.CaseDescription:
             pt_table_parameters={
                 "PVT4": case_description.PvtModelTableParametersDescription.create_empty()
             },
+            ph_table_parameters={
+                "PVT5": case_description.PhPvtModelTableParametersDescription.create_empty()
+            },
         )
     )
 
@@ -521,9 +536,17 @@ class TestEnsureValidReferences:
                     profile=_empty_profile(),
                     segments=build_simple_segment(),
                 ),
+                case_description.PipeDescription(
+                    name="Pipe 6",
+                    pvt_model="PVT6",
+                    source="in",
+                    target="out",
+                    profile=_empty_profile(),
+                    segments=build_simple_segment(),
+                ),
             ],
         )
-        expect_message = "PVT model 'PVT5' selected on 'Pipe 5' is not declared on 'pvt_models', available pvt_models are: PVT1, PVT2, PVT3, PVT4"
+        expect_message = "PVT model 'PVT6' selected on 'Pipe 6' is not declared on 'pvt_models', available pvt_models are: PVT1, PVT2, PVT3, PVT4, PVT5"
         with pytest.raises(
             InvalidReferenceError,
             match=re.escape(expect_message),
@@ -753,26 +776,26 @@ class TestEnsureValidReferences:
             case.ensure_valid_references()
 
 
-def test_pvt_model_table_parameters_description_equal():
+def test_pvt_model_table_parameters_description_equal(table_parameters_description):
     import numpy as np
 
-    table_params_1 = case_description.PvtModelTableParametersDescription(
-        pressure_values=np.array([0.0]),
-        temperature_values=np.array([0.0]),
+    table_params_1 = table_parameters_description(
+        np.array([0.0]), # pressure values
+        np.array([0.0]), # temperature or enthalpy values
         table_variables=[],
         variable_names=[],
         number_of_phases=-1,
     )
-    table_params_2 = case_description.PvtModelTableParametersDescription(
-        pressure_values=np.array([0.0]),
-        temperature_values=np.array([0.0]),
+    table_params_2 = table_parameters_description(
+        np.array([0.0]), # pressure values
+        np.array([0.0]), # temperature or enthalpy values
         table_variables=[np.array([1, 2])],
         variable_names=[],
         number_of_phases=-1,
     )
-    table_params_3 = case_description.PvtModelTableParametersDescription(
-        pressure_values=np.array([0.0]),
-        temperature_values=np.array([0.0]),
+    table_params_3 = table_parameters_description(
+        np.array([0.0]), # pressure values
+        np.array([0.0]), # temperature or enthalpy values
         table_variables=[np.array([2, 3])],
         variable_names=[],
         number_of_phases=-1,
@@ -788,14 +811,20 @@ def test_pvt_model_table_parameters_description_equal():
     assert table_params_3 != table_params_2
 
 
-def test_pvt_model_table_parameters_description_post_init():
+def test_pvt_model_table_parameters_description_post_init(table_parameters_description):
     """
     Check that standard properties that have not been informed (None) is converted to np.nan
     for more details about this, check the docstring from  PvtModelTableParametersDescription.__attrs_post_init__
     """
     import numpy as np
 
-    table_params = case_description.PvtModelTableParametersDescription(
+    table_params = table_parameters_description(
+        # Required params
+        np.ndarray([1]), # pressure values
+        np.ndarray([1]), # temperature or enthalpy values
+        table_variables=[np.ndarray([1])],
+        variable_names=["str"],
+        # Optional params
         pressure_std=None,
         temperature_std=None,
         gas_density_std=None,
@@ -805,11 +834,6 @@ def test_pvt_model_table_parameters_description_post_init():
         gas_liquid_ratio=None,
         water_cut=None,
         total_water_fraction=None,
-        # Required params
-        pressure_values=np.ndarray([1]),
-        temperature_values=np.ndarray([1]),
-        table_variables=[np.ndarray([1])],
-        variable_names=["str"],
     )
     assert table_params.pressure_std.value is np.nan
     assert table_params.temperature_std.value is np.nan
@@ -823,7 +847,11 @@ def test_pvt_model_table_parameters_description_post_init():
 
     # The following check are only for coverage purpose
     assert table_params.pressure_unit == "Pa"
-    assert table_params.temperature_unit == "K"
+
+    if table_parameters_description == case_description.PvtModelTableParametersDescription:
+        assert table_params.temperature_unit == "K"
+    else:
+        assert table_params.enthalpy_unit == "J/kg"
 
 
 def test_numpy_array_validator():
@@ -1121,14 +1149,14 @@ def test_material_description_as_dict():
     }
 
 
-def test_pvt_model_table_parameters_description_equality():
+def test_pvt_model_table_parameters_description_equality(table_parameters_description):
     """
     Ensure that the custom PvtModelTableParametersDescription equality functions works properly
     since it was customized to suport ndarrays.
     """
     assert (
-        PvtModelTableParametersDescription.create_constant()
-        == PvtModelTableParametersDescription.create_constant()
+        table_parameters_description.create_constant()
+        == table_parameters_description.create_constant()
     )
 
 

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -905,7 +905,7 @@ def test_pvt_model_table_parameters_description_create_constant_ph_table():
     cp_g_ref = 1010.0
     h_l_ref = 104.86e3
 
-    pvt = case_description.PvtModelTableParametersDescription.create_constant_ph_table(
+    pvt = case_description.PhPvtModelTableParametersDescription.create_constant(
         ideal_gas=False,
         rho_g_ref=rho_g_ref,
         cp_g_ref=cp_g_ref,

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -951,9 +951,21 @@ def test_pvt_model_table_parameters_description_create_constant_ph_table():
 
     assert pvt.table_variables[0] == approx(gas_density_expected_values)
     assert pvt.table_variables[1] == approx(gas_density_derivative_expected_values)
-    # The temperature must be at list last position
+    # Temperature must be at last position
     assert pvt.table_variables[-1] == approx(temperature_expected_values)
 
+def test_pvt_model_table_parameters_description_create_ph_table_with_dummy_dict():
+    """
+    Ensure that the dummy dict can create a dummy PH table
+    """
+    import numpy as np
+
+    dummy_dict = case_description.PvtModelPhTableParametersDescription.dummy_parameters_dict()
+
+    ph_table_description = case_description.PvtModelPhTableParametersDescription(**dummy_dict)
+
+    assert ph_table_description.enthalpy_values == np.array([0.0])
+    assert ph_table_description.variable_names == []
 
 def test_get_value_and_unit_from_length_and_elevation_description_and_xand_ydescription():
     """

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -50,8 +50,8 @@ from alfasim_sdk._internal.alfacase.case_description_attributes import to_curve
 # implement some tests for the both
 @pytest.fixture(
     params=(
-        case_description.PvtModelTableParametersDescription,
-        case_description.PhPvtModelTableParametersDescription
+        case_description.PvtModelPtTableParametersDescription,
+        case_description.PvtModelPhTableParametersDescription
     ),
     ids=(
         "pt_table_description", "ph_table_description"
@@ -304,10 +304,10 @@ def default_case(tmp_path) -> case_description.CaseDescription:
             correlations={"PVT2": case_description.PvtModelCorrelationDescription()},
             compositional={"PVT3": case_description.PvtModelCompositionalDescription()},
             pt_table_parameters={
-                "PVT4": case_description.PvtModelTableParametersDescription.create_empty()
+                "PVT4": case_description.PvtModelPtTableParametersDescription.create_empty()
             },
             ph_table_parameters={
-                "PVT5": case_description.PhPvtModelTableParametersDescription.create_empty()
+                "PVT5": case_description.PvtModelPhTableParametersDescription.create_empty()
             },
         )
     )
@@ -814,7 +814,7 @@ def test_pvt_model_table_parameters_description_equal(table_parameters_descripti
 def test_pvt_model_table_parameters_description_post_init(table_parameters_description):
     """
     Check that standard properties that have not been informed (None) is converted to np.nan
-    for more details about this, check the docstring from  PvtModelTableParametersDescription.__attrs_post_init__
+    for more details about this, check the docstring from  PvtModelPtTableParametersDescription.__attrs_post_init__
     """
     import numpy as np
 
@@ -848,7 +848,7 @@ def test_pvt_model_table_parameters_description_post_init(table_parameters_descr
     # The following check are only for coverage purpose
     assert table_params.pressure_unit == "Pa"
 
-    if table_parameters_description == case_description.PvtModelTableParametersDescription:
+    if table_parameters_description == case_description.PvtModelPtTableParametersDescription:
         assert table_params.temperature_unit == "K"
     else:
         assert table_params.enthalpy_unit == "J/kg"
@@ -907,7 +907,7 @@ def test_pvt_model_table_parameters_description_create_constant():
     rho_g_ref = 42.0
     gas_density_expected_values = rho_g_ref + 0 * p.flatten()
 
-    pvt = case_description.PvtModelTableParametersDescription.create_constant(
+    pvt = case_description.PvtModelPtTableParametersDescription.create_constant(
         ideal_gas=False, rho_g_ref=rho_g_ref
     )
     # Check gas_density_derivative_respect_pressure
@@ -933,7 +933,7 @@ def test_pvt_model_table_parameters_description_create_constant_ph_table():
     cp_g_ref = 1010.0
     h_l_ref = 104.86e3
 
-    pvt = case_description.PhPvtModelTableParametersDescription.create_constant(
+    pvt = case_description.PvtModelPhTableParametersDescription.create_constant(
         ideal_gas=False,
         rho_g_ref=rho_g_ref,
         cp_g_ref=cp_g_ref,
@@ -1151,7 +1151,7 @@ def test_material_description_as_dict():
 
 def test_pvt_model_table_parameters_description_equality(table_parameters_description):
     """
-    Ensure that the custom PvtModelTableParametersDescription equality functions works properly
+    Ensure that the custom PvtModelPtTableParametersDescription equality functions works properly
     since it was customized to suport ndarrays.
     """
     assert (

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -51,14 +51,13 @@ from alfasim_sdk._internal.alfacase.case_description_attributes import to_curve
 @pytest.fixture(
     params=(
         case_description.PvtModelPtTableParametersDescription,
-        case_description.PvtModelPhTableParametersDescription
+        case_description.PvtModelPhTableParametersDescription,
     ),
-    ids=(
-        "pt_table_description", "ph_table_description"
-    )
+    ids=("pt_table_description", "ph_table_description"),
 )
 def table_parameters_description(request):
     return request.param
+
 
 def test_physics_description_path_validator(tmp_path):
     """
@@ -780,22 +779,22 @@ def test_pvt_model_table_parameters_description_equal(table_parameters_descripti
     import numpy as np
 
     table_params_1 = table_parameters_description(
-        np.array([0.0]), # pressure values
-        np.array([0.0]), # temperature or enthalpy values
+        np.array([0.0]),  # pressure values
+        np.array([0.0]),  # temperature or enthalpy values
         table_variables=[],
         variable_names=[],
         number_of_phases=-1,
     )
     table_params_2 = table_parameters_description(
-        np.array([0.0]), # pressure values
-        np.array([0.0]), # temperature or enthalpy values
+        np.array([0.0]),  # pressure values
+        np.array([0.0]),  # temperature or enthalpy values
         table_variables=[np.array([1, 2])],
         variable_names=[],
         number_of_phases=-1,
     )
     table_params_3 = table_parameters_description(
-        np.array([0.0]), # pressure values
-        np.array([0.0]), # temperature or enthalpy values
+        np.array([0.0]),  # pressure values
+        np.array([0.0]),  # temperature or enthalpy values
         table_variables=[np.array([2, 3])],
         variable_names=[],
         number_of_phases=-1,
@@ -820,8 +819,8 @@ def test_pvt_model_table_parameters_description_post_init(table_parameters_descr
 
     table_params = table_parameters_description(
         # Required params
-        np.ndarray([1]), # pressure values
-        np.ndarray([1]), # temperature or enthalpy values
+        np.ndarray([1]),  # pressure values
+        np.ndarray([1]),  # temperature or enthalpy values
         table_variables=[np.ndarray([1])],
         variable_names=["str"],
         # Optional params
@@ -848,7 +847,10 @@ def test_pvt_model_table_parameters_description_post_init(table_parameters_descr
     # The following check are only for coverage purpose
     assert table_params.pressure_unit == "Pa"
 
-    if table_parameters_description == case_description.PvtModelPtTableParametersDescription:
+    if (
+        table_parameters_description
+        == case_description.PvtModelPtTableParametersDescription
+    ):
         assert table_params.temperature_unit == "K"
     else:
         assert table_params.enthalpy_unit == "J/kg"
@@ -954,18 +956,24 @@ def test_pvt_model_table_parameters_description_create_constant_ph_table():
     # Temperature must be at last position
     assert pvt.table_variables[-1] == approx(temperature_expected_values)
 
+
 def test_pvt_model_table_parameters_description_create_ph_table_with_dummy_dict():
     """
     Ensure that the dummy dict can create a dummy PH table
     """
     import numpy as np
 
-    dummy_dict = case_description.PvtModelPhTableParametersDescription.dummy_parameters_dict()
+    dummy_dict = (
+        case_description.PvtModelPhTableParametersDescription.dummy_parameters_dict()
+    )
 
-    ph_table_description = case_description.PvtModelPhTableParametersDescription(**dummy_dict)
+    ph_table_description = case_description.PvtModelPhTableParametersDescription(
+        **dummy_dict
+    )
 
     assert ph_table_description.enthalpy_values == np.array([0.0])
     assert ph_table_description.variable_names == []
+
 
 def test_get_value_and_unit_from_length_and_elevation_description_and_xand_ydescription():
     """

--- a/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
@@ -159,14 +159,14 @@ def build_constant_pvt_table(
         return case_description.PvtModelsDescription(
             default_model='constant pt table',
             pt_table_parameters={
-                'constant pt table': case_description.PvtModelTableParametersDescription.create_constant()
+                'constant pt table': case_description.PvtModelPtTableParametersDescription.create_constant()
             },
         )
     elif energy_model_primary_variable == constants.EnergyModelPrimaryVariable.Enthalpy:
         return case_description.PvtModelsDescription(
             default_model='constant ph table',
             ph_table_parameters={
-                'constant ph table': case_description.PhPvtModelTableParametersDescription.create_constant()
+                'constant ph table': case_description.PvtModelPhTableParametersDescription.create_constant()
             },
         )
     else:  # pragma no cover

--- a/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
@@ -156,10 +156,18 @@ def build_constant_pvt_table(
         energy_model_primary_variable
         == constants.EnergyModelPrimaryVariable.Temperature
     ):
-        return case_description.PvtModelTableParametersDescription.create_constant()
+        return case_description.PvtModelsDescription(
+            default_model='constant pt table',
+            pt_table_parameters={
+                'constant pt table': case_description.PvtModelTableParametersDescription.create_constant()
+            },
+        )
     elif energy_model_primary_variable == constants.EnergyModelPrimaryVariable.Enthalpy:
-        return (
-            case_description.PvtModelTableParametersDescription.create_constant_ph_table()
+        return case_description.PvtModelsDescription(
+            default_model='constant ph table',
+            ph_table_parameters={
+                'constant ph table': case_description.PhPvtModelTableParametersDescription.create_constant()
+            },
         )
     else:  # pragma no cover
         assert False, f"{energy_model_primary_variable} not supported."

--- a/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
@@ -157,16 +157,16 @@ def build_constant_pvt_table(
         == constants.EnergyModelPrimaryVariable.Temperature
     ):
         return case_description.PvtModelsDescription(
-            default_model='constant pt table',
+            default_model="constant pt table",
             pt_table_parameters={
-                'constant pt table': case_description.PvtModelPtTableParametersDescription.create_constant()
+                "constant pt table": case_description.PvtModelPtTableParametersDescription.create_constant()
             },
         )
     elif energy_model_primary_variable == constants.EnergyModelPrimaryVariable.Enthalpy:
         return case_description.PvtModelsDescription(
-            default_model='constant ph table',
+            default_model="constant ph table",
             ph_table_parameters={
-                'constant ph table': case_description.PvtModelPhTableParametersDescription.create_constant()
+                "constant ph table": case_description.PvtModelPhTableParametersDescription.create_constant()
             },
         )
     else:  # pragma no cover

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -80,10 +80,14 @@ PVT_MODEL_COMBINED_DEFINITION = case_description.PvtModelCombinedDescription(
     fluids={"combined_fluid_1": COMBINED_FLUID_DESCRIPTION},
 )
 PVT_MODEL_PT_TABLE_PARAMETERS = (
-    case_description.PvtModelPtTableParametersDescription.create_constant(has_water=True)
+    case_description.PvtModelPtTableParametersDescription.create_constant(
+        has_water=True
+    )
 )
 PVT_MODEL_PH_TABLE_PARAMETERS = (
-    case_description.PvtModelPhTableParametersDescription.create_constant(has_water=True)
+    case_description.PvtModelPhTableParametersDescription.create_constant(
+        has_water=True
+    )
 )
 PVT_MODELS_DEFINITION = case_description.PvtModelsDescription(
     default_model="acme",

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -80,10 +80,10 @@ PVT_MODEL_COMBINED_DEFINITION = case_description.PvtModelCombinedDescription(
     fluids={"combined_fluid_1": COMBINED_FLUID_DESCRIPTION},
 )
 PVT_MODEL_PT_TABLE_PARAMETERS = (
-    case_description.PvtModelTableParametersDescription.create_constant(has_water=True)
+    case_description.PvtModelPtTableParametersDescription.create_constant(has_water=True)
 )
 PVT_MODEL_PH_TABLE_PARAMETERS = (
-    case_description.PhPvtModelTableParametersDescription.create_constant(has_water=True)
+    case_description.PvtModelPhTableParametersDescription.create_constant(has_water=True)
 )
 PVT_MODELS_DEFINITION = case_description.PvtModelsDescription(
     default_model="acme",

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -79,8 +79,11 @@ PVT_MODEL_COMBINED_DEFINITION = case_description.PvtModelCombinedDescription(
     reference_pvt_model="acme",
     fluids={"combined_fluid_1": COMBINED_FLUID_DESCRIPTION},
 )
-PVT_MODEL_TABLE_PARAMETERS = (
+PVT_MODEL_PT_TABLE_PARAMETERS = (
     case_description.PvtModelTableParametersDescription.create_constant(has_water=True)
+)
+PVT_MODEL_PH_TABLE_PARAMETERS = (
+    case_description.PhPvtModelTableParametersDescription.create_constant(has_water=True)
 )
 PVT_MODELS_DEFINITION = case_description.PvtModelsDescription(
     default_model="acme",

--- a/tests/test_case_builders.py
+++ b/tests/test_case_builders.py
@@ -130,12 +130,12 @@ def test_build_compressor_pressure_table_description_invalid(
 @pytest.mark.parametrize(
     "energy_model_primary_variable, table_name",
     [
-        (constants.EnergyModelPrimaryVariable.Temperature,
-         'constant pt table',
-         ),
-        (constants.EnergyModelPrimaryVariable.Enthalpy,
-         'constant ph table'),
-    ]
+        (
+            constants.EnergyModelPrimaryVariable.Temperature,
+            "constant pt table",
+        ),
+        (constants.EnergyModelPrimaryVariable.Enthalpy, "constant ph table"),
+    ],
 )
 def test_build_constant_pvt_table(energy_model_primary_variable, table_name):
 

--- a/tests/test_case_builders.py
+++ b/tests/test_case_builders.py
@@ -127,12 +127,18 @@ def test_build_compressor_pressure_table_description_invalid(
         )
 
 
-def test_build_constant_pvt_table():
-    import numpy as np
+@pytest.mark.parametrize(
+    "energy_model_primary_variable, table_name",
+    [
+        (constants.EnergyModelPrimaryVariable.Temperature,
+         'constant pt table',
+         ),
+        (constants.EnergyModelPrimaryVariable.Enthalpy,
+         'constant ph table'),
+    ]
+)
+def test_build_constant_pvt_table(energy_model_primary_variable, table_name):
 
-    for energy_model_primary_variable in constants.EnergyModelPrimaryVariable:
-        table_description = build_constant_pvt_table(energy_model_primary_variable)
+    pvt_model_description = build_constant_pvt_table(energy_model_primary_variable)
 
-        assert np.array_equal(
-            table_description.pressure_values, np.linspace(0.5, 1e10, 4)
-        )
+    assert pvt_model_description.default_model == table_name


### PR DESCRIPTION
The major idea os this PR is to refactor the PH tables model to keep it independent from the other models. A new TableDescription have been created exclusivly to the PH model.

With this approach the `TableType` enum is no more required, since the table check is done intirely based on the PVT model.

Also, now the `build_constant_pvt_table` build a `PvtModel` description that will fill the `ph` or `pt` table parameter with the right `TableDescription`.