### PR TITLE
ASIM-4926-Change esp workflow

### DIFF
--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -254,6 +254,7 @@ from alfasim_sdk._internal.constants import MassInflowSplitType
 from alfasim_sdk._internal.constants import MassSourceType
 from alfasim_sdk._internal.constants import MaterialType
 from alfasim_sdk._internal.constants import MultiInputType
+from alfasim_sdk._internal.constants import EspParameters
 from alfasim_sdk._internal.constants import NodeCellType
 from alfasim_sdk._internal.constants import NonlinearSolverType
 from alfasim_sdk._internal.constants import OIL_FIELD
@@ -431,6 +432,7 @@ __all__ = [
     "MaterialDescription",
     "MaterialType",
     "MultiInputType",
+    "EspParameters",
     "MultipleReference",
     "NodeCellType",
     "NodeDescription",

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -363,14 +363,17 @@ class PumpType(Enum):
     TableInterpolation = "table_interpolation"
     ElectricSubmersiblePump = "electric_submersible_pump"
 
+
 class EspParameters(Enum):
     """
     Defines if a esp is imported from catalog or defined by user.
         - ``UserDefined``: The user will define the esp table values.
         - ``Catalog``: The esp table values will be populated by the data imported from the catalog.
     """
+
     UserDefined = "user_defined"
     Catalog = "catalog"
+
 
 class ValveOpeningType(Enum):
     ConstantOpening = "constant_opening"

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -363,6 +363,14 @@ class PumpType(Enum):
     TableInterpolation = "table_interpolation"
     ElectricSubmersiblePump = "electric_submersible_pump"
 
+class EspParameters(Enum):
+    """
+    Defines if a esp is imported from catalog or defined by user.
+        - ``UserDefined``: The user will define the esp table values.
+        - ``Catalog``: The esp table values will be populated by the data imported from the catalog.
+    """
+    UserDefined = "user_defined"
+    Catalog = "catalog"
 
 class ValveOpeningType(Enum):
     ConstantOpening = "constant_opening"


### PR DESCRIPTION
In ASIM-4926 it was necessary to add the EspParameters import in the module's __init__ and configure this enum with auto()