### PR TITLE
Add viscosity correction model enum

### DIFF
--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -231,6 +231,7 @@ from alfasim_sdk._internal.constants import EnergyModel
 from alfasim_sdk._internal.constants import EnergyModelPrimaryVariable
 from alfasim_sdk._internal.constants import EquationOfStateType
 from alfasim_sdk._internal.constants import EquipmentAttachmentLocation
+from alfasim_sdk._internal.constants import EspParameters
 from alfasim_sdk._internal.constants import EvaluationStrategyType
 from alfasim_sdk._internal.constants import EXTRAS_REQUIRED_VERSION_KEY
 from alfasim_sdk._internal.constants import FlashModel
@@ -254,7 +255,6 @@ from alfasim_sdk._internal.constants import MassInflowSplitType
 from alfasim_sdk._internal.constants import MassSourceType
 from alfasim_sdk._internal.constants import MaterialType
 from alfasim_sdk._internal.constants import MultiInputType
-from alfasim_sdk._internal.constants import EspParameters
 from alfasim_sdk._internal.constants import NodeCellType
 from alfasim_sdk._internal.constants import NonlinearSolverType
 from alfasim_sdk._internal.constants import OIL_FIELD
@@ -269,6 +269,7 @@ from alfasim_sdk._internal.constants import (
 from alfasim_sdk._internal.constants import PipeThermalModelType
 from alfasim_sdk._internal.constants import PipeThermalPositionInput
 from alfasim_sdk._internal.constants import PumpType
+from alfasim_sdk._internal.constants import PumpViscosityModel
 from alfasim_sdk._internal.constants import PVTCompositionalViscosityModel
 from alfasim_sdk._internal.constants import SeparatorGeometryType
 from alfasim_sdk._internal.constants import SimulationModeType
@@ -463,6 +464,7 @@ __all__ = [
     "ProfileOutputDescription",
     "PumpEquipmentDescription",
     "PumpType",
+    "PumpViscosityModel",
     "PvtModelCombinedDescription",
     "PvtModelCompositionalDescription",
     "PvtModelCorrelationDescription",

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -374,6 +374,7 @@ class EspParameters(Enum):
     UserDefined = "user_defined"
     Catalog = "catalog"
 
+
 class ValveOpeningType(Enum):
     ConstantOpening = "constant_opening"
     TableInterpolation = "table_interpolation"
@@ -384,14 +385,17 @@ class ValveType(Enum):
     ChokeValveWithFlowCoefficient = "choke_valve_with_flow_coefficient"
     CheckValve = "check_valve"
 
+
 class PumpViscosityModel(Enum):
     """
     Defines a viscosity model correction to Esp.
         - ``NoModel``: Viscosity model correction is disabled.
         - ``AnsiHi2010``: Applies the viscosity correction ANSI HI 2010.
     """
+
     NoModel = "no_model"
     AnsiHi2010 = "ansihi_2010"
+
 
 class LeakModel(Enum):
     Orifice = "orifice"

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -374,7 +374,6 @@ class EspParameters(Enum):
     UserDefined = "user_defined"
     Catalog = "catalog"
 
-
 class ValveOpeningType(Enum):
     ConstantOpening = "constant_opening"
     TableInterpolation = "table_interpolation"
@@ -385,6 +384,14 @@ class ValveType(Enum):
     ChokeValveWithFlowCoefficient = "choke_valve_with_flow_coefficient"
     CheckValve = "check_valve"
 
+class PumpViscosityModel(Enum):
+    """
+    Defines a viscosity model correction to Esp.
+        - ``NoModel``: Viscosity model correction is disabled.
+        - ``AnsiHi2010``: Applies the viscosity correction ANSI HI 2010.
+    """
+    NoModel = "no_model"
+    AnsiHi2010 = "ansihi_2010"
 
 class LeakModel(Enum):
     Orifice = "orifice"


### PR DESCRIPTION
Adds a enum to enable users in alfasim_gui select the viscosity correction model.