### PR TITLE
Add esp_parameters in PumpEquipmentDescription

### DIFF
--- a/docs/source/alfacase_definitions/PumpEquipmentDescription.txt
+++ b/docs/source/alfacase_definitions/PumpEquipmentDescription.txt
@@ -19,6 +19,7 @@
             esp_speed_curve: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(Hz, s)[]
             esp_number_of_stages: int = 1
             esp_reference_density: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.0, 'kg/m3', 'density')
+            user_defined_esp_table: \ :class:`TablePumpDescription <TablePumpDescription>`\  = TablePumpDescription()
 
 .. tab:: Schema
 
@@ -54,3 +55,4 @@
             esp_reference_density:  # optional
                 value: number
                 unit: string
+            user_defined_esp_table: \ :class:`table_pump_description_schema <TablePumpDescription>`\  # optional

--- a/docs/source/alfacase_definitions/PumpEquipmentDescription.txt
+++ b/docs/source/alfacase_definitions/PumpEquipmentDescription.txt
@@ -20,6 +20,7 @@
             esp_number_of_stages: int = 1
             esp_reference_density: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.0, 'kg/m3', 'density')
             user_defined_esp_table: \ :class:`TablePumpDescription <TablePumpDescription>`\  = TablePumpDescription()
+            esp_parameters: \ :class:`EspParameters <alfasim_sdk._internal.constants.EspParameters>`\  = EspParameters.UserDefined
 
 .. tab:: Schema
 
@@ -56,3 +57,4 @@
                 value: number
                 unit: string
             user_defined_esp_table: \ :class:`table_pump_description_schema <TablePumpDescription>`\  # optional
+            esp_parameters: \ :class:`EspParameters <alfasim_sdk._internal.constants.EspParameters>`\  # optional

--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -269,7 +269,6 @@ from alfasim_sdk._internal.constants import (
 from alfasim_sdk._internal.constants import PipeThermalModelType
 from alfasim_sdk._internal.constants import PipeThermalPositionInput
 from alfasim_sdk._internal.constants import PumpType
-from alfasim_sdk._internal.constants import PumpViscosityModel
 from alfasim_sdk._internal.constants import PVTCompositionalViscosityModel
 from alfasim_sdk._internal.constants import SeparatorGeometryType
 from alfasim_sdk._internal.constants import SimulationModeType

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -757,6 +757,7 @@ class PumpEquipmentDescription:
     esp_reference_density = attrib_scalar(
         category="density", default=Scalar(0.0, "kg/m3")
     )
+    user_defined_esp_table = attrib_instance(TablePumpDescription)
 
 
 @attr.s(frozen=True, slots=True)

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2,41 +2,25 @@ from contextlib import suppress
 from datetime import datetime
 from numbers import Number
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import Iterator
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import Union
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import attr
 import numpy as np
-from attr.validators import in_
-from attr.validators import instance_of
-from attr.validators import optional
+from attr.validators import in_, instance_of, optional
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from .case_description_attributes import attrib_array
-from .case_description_attributes import attrib_curve
-from .case_description_attributes import attrib_dict_of
-from .case_description_attributes import attrib_enum
-from .case_description_attributes import attrib_instance
-from .case_description_attributes import attrib_instance_list
-from .case_description_attributes import attrib_scalar
-from .case_description_attributes import collapse_array_repr
-from .case_description_attributes import dict_of
-from .case_description_attributes import dict_of_array
-from .case_description_attributes import dict_with_scalar
-from .case_description_attributes import InvalidReferenceError
-from .case_description_attributes import list_of_strings
-from .case_description_attributes import Numpy1DArray
-from .case_description_attributes import numpy_array_validator
-from .case_description_attributes import PhaseName
 from alfasim_sdk._internal import constants
+
+from .case_description_attributes import (InvalidReferenceError, Numpy1DArray,
+                                          PhaseName, attrib_array,
+                                          attrib_curve, attrib_dict_of,
+                                          attrib_enum, attrib_instance,
+                                          attrib_instance_list, attrib_scalar,
+                                          collapse_array_repr, dict_of,
+                                          dict_of_array, dict_with_scalar,
+                                          list_of_strings,
+                                          numpy_array_validator)
 
 # [[[cog
 # # This cog has no output, it just declares and imports symbols used by cogs in this module.
@@ -758,7 +742,7 @@ class PumpEquipmentDescription:
         category="density", default=Scalar(0.0, "kg/m3")
     )
     user_defined_esp_table = attrib_instance(TablePumpDescription)
-
+    esp_parameters = attrib_enum(default=constants.EspParameters.UserDefined)
 
 @attr.s(frozen=True, slots=True)
 class CompressorPressureTableDescription:

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2,25 +2,41 @@ from contextlib import suppress
 from datetime import datetime
 from numbers import Number
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
 
 import attr
 import numpy as np
-from attr.validators import in_, instance_of, optional
+from attr.validators import in_
+from attr.validators import instance_of
+from attr.validators import optional
 from barril.curve.curve import Curve
-from barril.units import Array, Scalar
+from barril.units import Array
+from barril.units import Scalar
 
+from .case_description_attributes import attrib_array
+from .case_description_attributes import attrib_curve
+from .case_description_attributes import attrib_dict_of
+from .case_description_attributes import attrib_enum
+from .case_description_attributes import attrib_instance
+from .case_description_attributes import attrib_instance_list
+from .case_description_attributes import attrib_scalar
+from .case_description_attributes import collapse_array_repr
+from .case_description_attributes import dict_of
+from .case_description_attributes import dict_of_array
+from .case_description_attributes import dict_with_scalar
+from .case_description_attributes import InvalidReferenceError
+from .case_description_attributes import list_of_strings
+from .case_description_attributes import Numpy1DArray
+from .case_description_attributes import numpy_array_validator
+from .case_description_attributes import PhaseName
 from alfasim_sdk._internal import constants
-
-from .case_description_attributes import (InvalidReferenceError, Numpy1DArray,
-                                          PhaseName, attrib_array,
-                                          attrib_curve, attrib_dict_of,
-                                          attrib_enum, attrib_instance,
-                                          attrib_instance_list, attrib_scalar,
-                                          collapse_array_repr, dict_of,
-                                          dict_of_array, dict_with_scalar,
-                                          list_of_strings,
-                                          numpy_array_validator)
 
 # [[[cog
 # # This cog has no output, it just declares and imports symbols used by cogs in this module.
@@ -743,6 +759,7 @@ class PumpEquipmentDescription:
     )
     user_defined_esp_table = attrib_instance(TablePumpDescription)
     esp_parameters = attrib_enum(default=constants.EspParameters.UserDefined)
+
 
 @attr.s(frozen=True, slots=True)
 class CompressorPressureTableDescription:

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -10,9 +10,8 @@
 # for class_ in list_of_classes_that_needs_schema:
 #    cog.out(generate_alfacase_schema(class_))
 # ]]]
-from strictyaml import Any, Bool, Enum, Int, Map, MapPattern, Optional, Seq, Str, Float # noreorder
-
-
+from strictyaml import (Any, Bool, Enum, Float, Int, Map,  # noreorder
+                        MapPattern, Optional, Seq, Str)
 
 bip_description_schema = Map(
     {
@@ -946,6 +945,7 @@ pump_equipment_description_schema = Map(
         Optional("esp_number_of_stages"): Int(),
         Optional("esp_reference_density"): Map({"value": Float(), "unit": Str()}),
         Optional("user_defined_esp_table"): table_pump_description_schema,
+        Optional("esp_parameters"): Enum(['user_defined', 'catalog']),
     }
 )
 pvt_model_combined_description_schema = Map(
@@ -1135,5 +1135,5 @@ case_description_schema = Map(
         Optional("walls"): Seq(wall_description_schema),
     }
 )
-# [[[end]]] (checksum: 429f7a4f74f7f82d4c4005913de3e23f)
+# [[[end]]] (checksum: c50d2142cad3955565aa153440c142fd)
 # fmt: on

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -10,8 +10,9 @@
 # for class_ in list_of_classes_that_needs_schema:
 #    cog.out(generate_alfacase_schema(class_))
 # ]]]
-from strictyaml import (Any, Bool, Enum, Float, Int, Map,  # noreorder
-                        MapPattern, Optional, Seq, Str)
+from strictyaml import Any, Bool, Enum, Int, Map, MapPattern, Optional, Seq, Str, Float # noreorder
+
+
 
 bip_description_schema = Map(
     {

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -945,6 +945,7 @@ pump_equipment_description_schema = Map(
         ),
         Optional("esp_number_of_stages"): Int(),
         Optional("esp_reference_density"): Map({"value": Float(), "unit": Str()}),
+        Optional("user_defined_esp_table"): table_pump_description_schema,
     }
 )
 pvt_model_combined_description_schema = Map(
@@ -1134,5 +1135,5 @@ case_description_schema = Map(
         Optional("walls"): Seq(wall_description_schema),
     }
 )
-# [[[end]]] (checksum: 0d1c4f2308285b6cae0f4472304733f4)
+# [[[end]]] (checksum: 429f7a4f74f7f82d4c4005913de3e23f)
 # fmt: on

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -386,17 +386,6 @@ class ValveType(Enum):
     CheckValve = "check_valve"
 
 
-class PumpViscosityModel(Enum):
-    """
-    Defines a viscosity model correction to Esp.
-        - ``NoModel``: Viscosity model correction is disabled.
-        - ``AnsiHi2010``: Applies the viscosity correction ANSI HI 2010.
-    """
-
-    NoModel = "no_model"
-    AnsiHi2010 = "ansihi_2010"
-
-
 class LeakModel(Enum):
     Orifice = "orifice"
     FlowCoefficient = "flow_coefficient"

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PumpEquipmentDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PumpEquipmentDescription_.txt
@@ -19,6 +19,7 @@
             esp_speed_curve: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(Hz, s)[]
             esp_number_of_stages: int = 1
             esp_reference_density: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.0, 'kg/m3', 'density')
+            user_defined_esp_table: \ :class:`TablePumpDescription <TablePumpDescription>`\  = TablePumpDescription()
 
 .. tab:: Schema
 
@@ -54,3 +55,4 @@
             esp_reference_density:  # optional
                 value: number
                 unit: string
+            user_defined_esp_table: \ :class:`table_pump_description_schema <TablePumpDescription>`\  # optional

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PumpEquipmentDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PumpEquipmentDescription_.txt
@@ -20,6 +20,7 @@
             esp_number_of_stages: int = 1
             esp_reference_density: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.0, 'kg/m3', 'density')
             user_defined_esp_table: \ :class:`TablePumpDescription <TablePumpDescription>`\  = TablePumpDescription()
+            esp_parameters: \ :class:`EspParameters <alfasim_sdk._internal.constants.EspParameters>`\  = EspParameters.UserDefined
 
 .. tab:: Schema
 
@@ -56,3 +57,4 @@
                 value: number
                 unit: string
             user_defined_esp_table: \ :class:`table_pump_description_schema <TablePumpDescription>`\  # optional
+            esp_parameters: \ :class:`EspParameters <alfasim_sdk._internal.constants.EspParameters>`\  # optional

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -1000,6 +1000,7 @@ pump_equipment_description_schema = Map(
         Optional("esp_number_of_stages"): Int(),
         Optional("esp_reference_density"): Map({"value": Float(), "unit": Str()}),
         Optional("user_defined_esp_table"): table_pump_description_schema,
+        Optional("esp_parameters"): Enum(['user_defined', 'catalog']),
     }
 )
 

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -999,6 +999,7 @@ pump_equipment_description_schema = Map(
         ),
         Optional("esp_number_of_stages"): Int(),
         Optional("esp_reference_density"): Map({"value": Float(), "unit": Str()}),
+        Optional("user_defined_esp_table"): table_pump_description_schema,
     }
 )
 

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -2,15 +2,14 @@ from pathlib import Path
 
 import numpy as np
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from . import case_builders
-from . import get_acme_tab_file_path
 from alfasim_sdk import LeakLocation
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
 from alfasim_sdk._internal.alfacase.alfacase_to_case import get_category_for
+
+from . import case_builders, get_acme_tab_file_path
 
 BIP_DESCRIPTION = case_description.BipDescription(
     component_1="C1", component_2="C2", value=0.5
@@ -505,6 +504,8 @@ PUMP_DESCRIPTION = case_description.PumpEquipmentDescription(
     ),
     esp_number_of_stages=2,
     esp_reference_density=Scalar(1000.0, "kg/m3"),
+    user_defined_esp_table=TABLE_PUMP_DESCRIPTION,
+    esp_parameters=constants.EspParameters.Catalog,
 )
 VALVE_DESCRIPTION = case_description.ValveEquipmentDescription(
     position=Scalar(100.0, "m"),

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -2,14 +2,15 @@ from pathlib import Path
 
 import numpy as np
 from barril.curve.curve import Curve
-from barril.units import Array, Scalar
+from barril.units import Array
+from barril.units import Scalar
 
+from . import case_builders
+from . import get_acme_tab_file_path
 from alfasim_sdk import LeakLocation
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
 from alfasim_sdk._internal.alfacase.alfacase_to_case import get_category_for
-
-from . import case_builders, get_acme_tab_file_path
 
 BIP_DESCRIPTION = case_description.BipDescription(
     component_1="C1", component_2="C2", value=0.5


### PR DESCRIPTION
Following ASIM-5017, it was necessary to add a `esp_parameters` field in `PumpEquipmentDescription` to cope with the two different `esp_tables`.