### PR TITLE
Force test job for py36/linux to use ubutu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest, windows-latest]
         include:
+          # non-matrix listed runs (python 3.6 is not supported with ubuntu-latest).
           - python-version: 3.6
+            os: ubuntu-20.04
             env: "py36"
+          - python-version: 3.6
+            os: windows-latest
+            env: "py36"
+          # "env" for matrix listed python runs.
           - python-version: 3.7
             env: "py37"
           - python-version: 3.8


### PR DESCRIPTION
Python 3.6 will no longer be supported on newer ubuntu version since it has reached end-of-live:
https://github.com/actions/setup-python/issues/544#issuecomment-1332535877