### PR TITLE
Allow ALFAsimTestingFixture to run simulations from CaseDescription 

### DIFF
--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -242,6 +242,8 @@ from alfasim_sdk._internal.constants import FlowDirection
 from alfasim_sdk._internal.constants import FlowPatternModel
 from alfasim_sdk._internal.constants import FLUID_GAS
 from alfasim_sdk._internal.constants import FLUID_OIL
+from alfasim_sdk._internal.constants import FLUID_DROPLET
+from alfasim_sdk._internal.constants import FLUID_BUBBLE
 from alfasim_sdk._internal.constants import FLUID_PHASE_NAMES
 from alfasim_sdk._internal.constants import FLUID_WATER
 from alfasim_sdk._internal.constants import GAS_FIELD
@@ -389,6 +391,8 @@ __all__ = [
     "EvaluationStrategyType",
     "FLUID_GAS",
     "FLUID_OIL",
+    'FLUID_BUBBLE',
+    'FLUID_DROPLET',
     "FLUID_PHASE_NAMES",
     "FLUID_WATER",
     "FileContent",

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -234,6 +234,8 @@ class MaterialType(Enum):
 FLUID_GAS = "gas"
 FLUID_OIL = "oil"
 FLUID_WATER = "water"
+FLUID_DROPLET = "droplet"
+FLUID_BUBBLE = "bubble"
 FLUID_PHASE_NAMES = [FLUID_GAS, FLUID_OIL, FLUID_WATER]
 
 

--- a/src/alfasim_sdk/testing/fixtures.py
+++ b/src/alfasim_sdk/testing/fixtures.py
@@ -66,7 +66,10 @@ class AlfasimRunnerFixture:
         self.check_not_run()
         self.check_base_case_is_not_loaded()
 
-        self._case = convert_alfacase_to_description(Path(*parts))
+        if len(parts) == 1 and isinstance(parts[0], CaseDescription):
+            self._case = parts[0]
+        else:
+            self._case = convert_alfacase_to_description(Path(*parts))
 
     def add_plugin_folder(self, *parts: Union[str, Path]) -> None:
         """


### PR DESCRIPTION
Since internally already exists a conversion from `alfacase` to `CaseDescription`, in order for the test case to be updated, it is a good approach to be possible to run a test case directly from a `CaseDescription`.

It also improves the simulation running process, which will be able to be performed by our two available text-based test case configurations.