### PR TITLE
[PYTHON 3.10] Refactored pyyaml code in order to avoid deprecated api

### DIFF
--- a/src/alfasim_sdk/_internal/alfacase/alfatable.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfatable.py
@@ -33,11 +33,12 @@ def load_pvt_model_table_parameters_description_from_alfatable(
     """
     Load the content from the alfatable in the given file_path. The validation is turned off due to performance issues.
     """
-    from ruamel import yaml as ruamelyaml
+    from ruamel.yaml.main import YAML
     from barril.units import Scalar
     import numpy as np
 
-    content = ruamelyaml.safe_load(Path(file_path).read_text(encoding="UTF-8"))
+    yaml = YAML(typ="safe", pure=True)
+    content = yaml.load(Path(file_path))
 
     table_parameter_keys_and_values = {
         "pressure_values": np.array(content["pressure_values"]),


### PR DESCRIPTION
- Simple refactoring to avoid deprecated api (which will give a warning msg in python 3.10)

EDEN-2592