### PR TITLE
ASIM-5167 - Parametric variables not working in emulsion model

### DIFF
--- a/docs/source/alfacase_definitions/EmulsionModelCurveDescription.txt
+++ b/docs/source/alfacase_definitions/EmulsionModelCurveDescription.txt
@@ -1,0 +1,20 @@
+.. rubric:: Definitions
+
+.. tab:: CaseDescription
+
+    .. parsed-literal::
+
+        class EmulsionModelCurveDescription
+            domain: \ :class:`Array <barril.units.Array>`\  = Array(dimensionless, [0.0], m3/m3)
+            image: \ :class:`Array <barril.units.Array>`\  = Array(dimensionless, [1.0], -)
+
+.. tab:: Schema
+
+    .. parsed-literal::
+
+            domain:  # optional
+                values: [number]
+                unit: string
+            image:  # optional
+                values: [number]
+                unit: string

--- a/docs/source/alfacase_definitions/PhysicsDescription.txt
+++ b/docs/source/alfacase_definitions/PhysicsDescription.txt
@@ -18,8 +18,8 @@
             emulsion_pal_rhodes_phi_rel_100: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.765, '-', 'dimensionless')
             emulsion_woelflin_a: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(4.2, '-', 'dimensionless')
             emulsion_woelflin_b: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(2.5, '-', 'dimensionless')
-            emulsion_table_based_rel_visc_curve: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(-, m3/m3)[(1.0, 0.0)]
-            emulsion_relative_viscosity_tuning_factor: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(-, m3/m3)[(1.0, 0.0)]
+            emulsion_table_based_rel_visc_curve: \ :class:`EmulsionModelCurveDescription <EmulsionModelCurveDescription>`\  = EmulsionModelCurveDescription()
+            emulsion_relative_viscosity_tuning_factor: \ :class:`EmulsionModelCurveDescription <EmulsionModelCurveDescription>`\  = EmulsionModelCurveDescription()
             emulsion_droplet_size_model: \ :class:`EmulsionDropletSizeModelType <alfasim_sdk._internal.constants.EmulsionDropletSizeModelType>`\  = EmulsionDropletSizeModelType.ModelDefault
             emulsion_inversion_point_model: \ :class:`EmulsionInversionPointModelType <alfasim_sdk._internal.constants.EmulsionInversionPointModelType>`\  = EmulsionInversionPointModelType.ModelDefault
             emulsion_inversion_water_cut: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.4, 'm3/m3', 'volume per volume')
@@ -49,20 +49,8 @@
             emulsion_woelflin_b:  # optional
                 value: number
                 unit: string
-            emulsion_table_based_rel_visc_curve:  # optional
-                image:
-                    values: [number]
-                    unit: string
-                domain:
-                    values: [number]
-                    unit: string
-            emulsion_relative_viscosity_tuning_factor:  # optional
-                image:
-                    values: [number]
-                    unit: string
-                domain:
-                    values: [number]
-                    unit: string
+            emulsion_table_based_rel_visc_curve: \ :class:`emulsion_model_curve_description_schema <EmulsionModelCurveDescription>`\  # optional
+            emulsion_relative_viscosity_tuning_factor: \ :class:`emulsion_model_curve_description_schema <EmulsionModelCurveDescription>`\  # optional
             emulsion_droplet_size_model: \ :class:`EmulsionDropletSizeModelType <alfasim_sdk._internal.constants.EmulsionDropletSizeModelType>`\  # optional
             emulsion_inversion_point_model: \ :class:`EmulsionInversionPointModelType <alfasim_sdk._internal.constants.EmulsionInversionPointModelType>`\  # optional
             emulsion_inversion_water_cut:  # optional

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -609,6 +609,17 @@ class SpeedCurveDescription:
     time = attrib_array(Array([0], "s"))
     speed = attrib_array(Array([500], "rpm"), category="angle per time")
 
+@attr.s(frozen=True, slots=True, kw_only=True)
+class EmulsionModelCurveDescription:
+    """
+    ivar: domain:
+
+    ivar: image:
+
+    """
+    domain = attrib_array(Array([0.0], "m3/m3"), category="volume per volume")
+    image = attrib_array(Array([1.0], '-'), category="dimensionless")
+
 
 # fmt: off
 @attr.s(frozen=True, slots=True, kw_only=True)
@@ -3176,19 +3187,8 @@ class PhysicsDescription:
     )
     emulsion_woelflin_a = attrib_scalar(default=Scalar("dimensionless", 4.2, "-"))
     emulsion_woelflin_b = attrib_scalar(default=Scalar("dimensionless", 2.5, "-"))
-    emulsion_table_based_rel_visc_curve = attrib_curve(
-        default=Curve(
-            image=Array("dimensionless", [1.0], "-"),
-            domain=Array("volume per volume", [0.0], "m3/m3"),
-        )
-    )
-
-    emulsion_relative_viscosity_tuning_factor = attrib_curve(
-        default=Curve(
-            image=Array("dimensionless", [1.0], "-"),  # tuning factor
-            domain=Array("volume per volume", [0.0], "m3/m3"),  # water-cut
-        )
-    )
+    emulsion_table_based_rel_visc_curve = attrib_instance(EmulsionModelCurveDescription)
+    emulsion_relative_viscosity_tuning_factor = attrib_instance(EmulsionModelCurveDescription)
 
     emulsion_droplet_size_model = attrib_enum(
         default=constants.EmulsionDropletSizeModelType.ModelDefault
@@ -3216,16 +3216,15 @@ class PhysicsDescription:
 
     @emulsion_relative_viscosity_tuning_factor.validator
     def _validate_emulsion_relative_viscosity_tuning_factor(self, attribute, value):
-        domain = value.GetDomain()
-        assert domain.GetCategory() == "volume per volume", "Invalid water-cut category"
-        domain_values = np.asarray(domain.GetValues("m3/m3"))
+        assert value.domain.category == "volume per volume", "Invalid water-cut category"
+        domain_values = np.asarray(value.domain.GetValues("m3/m3"))
         assert (
             np.min(domain_values) >= 0.0 and np.max(domain_values) <= 1.0
         ), "Invalid water-cut values"
-        image = value.GetImage()
+
         assert (
-            image.GetCategory() == "dimensionless"
-            and np.min(image.GetValues("-")) >= 1.0e-5
+            value.image.category == "dimensionless"
+            and np.min(value.image.GetValues('-'))>= 1.0e-5
         ), "Tuning factor cannot be lower than 1e-5"
 
 

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -609,6 +609,7 @@ class SpeedCurveDescription:
     time = attrib_array(Array([0], "s"))
     speed = attrib_array(Array([500], "rpm"), category="angle per time")
 
+
 @attr.s(frozen=True, slots=True, kw_only=True)
 class EmulsionModelCurveDescription:
     """
@@ -617,8 +618,9 @@ class EmulsionModelCurveDescription:
     ivar: image:
 
     """
+
     domain = attrib_array(Array([0.0], "m3/m3"), category="volume per volume")
-    image = attrib_array(Array([1.0], '-'), category="dimensionless")
+    image = attrib_array(Array([1.0], "-"), category="dimensionless")
 
 
 # fmt: off
@@ -3188,7 +3190,9 @@ class PhysicsDescription:
     emulsion_woelflin_a = attrib_scalar(default=Scalar("dimensionless", 4.2, "-"))
     emulsion_woelflin_b = attrib_scalar(default=Scalar("dimensionless", 2.5, "-"))
     emulsion_table_based_rel_visc_curve = attrib_instance(EmulsionModelCurveDescription)
-    emulsion_relative_viscosity_tuning_factor = attrib_instance(EmulsionModelCurveDescription)
+    emulsion_relative_viscosity_tuning_factor = attrib_instance(
+        EmulsionModelCurveDescription
+    )
 
     emulsion_droplet_size_model = attrib_enum(
         default=constants.EmulsionDropletSizeModelType.ModelDefault
@@ -3216,7 +3220,9 @@ class PhysicsDescription:
 
     @emulsion_relative_viscosity_tuning_factor.validator
     def _validate_emulsion_relative_viscosity_tuning_factor(self, attribute, value):
-        assert value.domain.category == "volume per volume", "Invalid water-cut category"
+        assert (
+            value.domain.category == "volume per volume"
+        ), "Invalid water-cut category"
         domain_values = np.asarray(value.domain.GetValues("m3/m3"))
         assert (
             np.min(domain_values) >= 0.0 and np.max(domain_values) <= 1.0
@@ -3224,7 +3230,7 @@ class PhysicsDescription:
 
         assert (
             value.image.category == "dimensionless"
-            and np.min(value.image.GetValues('-'))>= 1.0e-5
+            and np.min(value.image.GetValues("-")) >= 1.0e-5
         ), "Tuning factor cannot be lower than 1e-5"
 
 

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -86,6 +86,12 @@ cv_table_description_schema = Map(
         Optional("flow_coefficient"): Map({"values": Seq(Float()), "unit": Str()}),
     }
 )
+emulsion_model_curve_description_schema = Map(
+    {
+        Optional("domain"): Map({"values": Seq(Float()), "unit": Str()}),
+        Optional("image"): Map({"values": Seq(Float()), "unit": Str()}),
+    }
+)
 environment_property_description_schema = Map(
     {
         "position": Map({"value": Float(), "unit": Str()}),
@@ -369,40 +375,6 @@ packer_description_schema = Map(
         "name": Str(),
         "position": Map({"value": Float(), "unit": Str()}),
         Optional("material_above"): Str(),
-    }
-)
-physics_description_schema = Map(
-    {
-        Optional("hydrodynamic_model"): Enum(['hydrodynamic_model_2_fields', 'hydrodynamic_model_4_fields', 'hydrodynamic_model_3_layers_gas_oil_water', 'hydrodynamic_model_5_fields_solid', 'hydrodynamic_model_5_fields_water', 'hydrodynamic_model_5_fields_co2', 'hydrodynamic_model_3_layers_no_bubble_gas_oil_water', 'hydrodynamic_model_3_layers_water_with_co2', 'hydrodynamic_model_3_layers_7_fields_gas_oil_water', 'hydrodynamic_model_3_layers_9_fields_gas_oil_water']),
-        Optional("simulation_regime"): Enum(['simulation_regime_transient', 'simulation_regime_steady_state']),
-        Optional("energy_model"): Enum(['no_model', 'global_model', 'layers_model']),
-        Optional("solids_model"): Enum(['no_model', 'thomas1965_equilibrium', 'mills1985_equilibrium', 'santamaria2010_equilibrium', 'from_plugin']),
-        Optional("solids_model_plugin_id"): Str(),
-        Optional("initial_condition_strategy"): Enum(['constant', 'steady_state', 'restart']),
-        Optional("restart_filepath"): Str(),
-        Optional("keep_former_results"): Bool(),
-        Optional("emulsion_model_enabled"): Bool(),
-        Optional("emulsion_relative_viscosity_model"): Enum(['model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'pal_rhodes1989', 'ronningsen1995', 'volumetric_weight', 'woelflin_1942', 'barnea_mizrahi1976', 'table_based', 'from_plugin']),
-        Optional("emulsion_pal_rhodes_phi_rel_100"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_woelflin_a"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_woelflin_b"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_table_based_rel_visc_curve"): Map(
-            {
-                "image": Map({"values": Seq(Float()), "unit": Str()}),
-                "domain": Map({"values": Seq(Float()), "unit": Str()}),
-            }
-        ),
-        Optional("emulsion_relative_viscosity_tuning_factor"): Map(
-            {
-                "image": Map({"values": Seq(Float()), "unit": Str()}),
-                "domain": Map({"values": Seq(Float()), "unit": Str()}),
-            }
-        ),
-        Optional("emulsion_droplet_size_model"): Enum(['model_default', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012']),
-        Optional("emulsion_inversion_point_model"): Enum(['model_default', 'brauner_and_ullmann_2002', 'brinkman1952_and_yeh1964', 'constant']),
-        Optional("emulsion_inversion_water_cut"): Map({"value": Float(), "unit": Str()}),
-        Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
-        Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
     }
 )
 pig_equipment_description_schema = Map(
@@ -908,6 +880,30 @@ leak_equipment_description_schema = Map(
         Optional("backpressure"): Map({"value": Float(), "unit": Str()}),
     }
 )
+physics_description_schema = Map(
+    {
+        Optional("hydrodynamic_model"): Enum(['hydrodynamic_model_2_fields', 'hydrodynamic_model_4_fields', 'hydrodynamic_model_3_layers_gas_oil_water', 'hydrodynamic_model_5_fields_solid', 'hydrodynamic_model_5_fields_water', 'hydrodynamic_model_5_fields_co2', 'hydrodynamic_model_3_layers_no_bubble_gas_oil_water', 'hydrodynamic_model_3_layers_water_with_co2', 'hydrodynamic_model_3_layers_7_fields_gas_oil_water', 'hydrodynamic_model_3_layers_9_fields_gas_oil_water']),
+        Optional("simulation_regime"): Enum(['simulation_regime_transient', 'simulation_regime_steady_state']),
+        Optional("energy_model"): Enum(['no_model', 'global_model', 'layers_model']),
+        Optional("solids_model"): Enum(['no_model', 'thomas1965_equilibrium', 'mills1985_equilibrium', 'santamaria2010_equilibrium', 'from_plugin']),
+        Optional("solids_model_plugin_id"): Str(),
+        Optional("initial_condition_strategy"): Enum(['constant', 'steady_state', 'restart']),
+        Optional("restart_filepath"): Str(),
+        Optional("keep_former_results"): Bool(),
+        Optional("emulsion_model_enabled"): Bool(),
+        Optional("emulsion_relative_viscosity_model"): Enum(['model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'pal_rhodes1989', 'ronningsen1995', 'volumetric_weight', 'woelflin_1942', 'barnea_mizrahi1976', 'table_based', 'from_plugin']),
+        Optional("emulsion_pal_rhodes_phi_rel_100"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_woelflin_a"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_woelflin_b"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_table_based_rel_visc_curve"): emulsion_model_curve_description_schema,
+        Optional("emulsion_relative_viscosity_tuning_factor"): emulsion_model_curve_description_schema,
+        Optional("emulsion_droplet_size_model"): Enum(['model_default', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012']),
+        Optional("emulsion_inversion_point_model"): Enum(['model_default', 'brauner_and_ullmann_2002', 'brinkman1952_and_yeh1964', 'constant']),
+        Optional("emulsion_inversion_water_cut"): Map({"value": Float(), "unit": Str()}),
+        Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
+        Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
+    }
+)
 positional_pipe_trend_description_schema = Map(
     {
         Optional("name"): Str(),
@@ -1139,5 +1135,5 @@ case_description_schema = Map(
         Optional("walls"): Seq(wall_description_schema),
     }
 )
-# [[[end]]] (checksum: faa375d759990e5ea0a82a2782fd826d)
+# [[[end]]] (checksum: be8188efd716f9d43922ad82cd7e28d6)
 # fmt: on

--- a/tests/alfacase/test_alfacase_to_case.py
+++ b/tests/alfacase/test_alfacase_to_case.py
@@ -143,7 +143,7 @@ ALFACASE_TEST_CONFIG_MAP = {
     "EmulsionModelCurveDescription": AlfacaseTestConfig(
         description_expected=filled_case_descriptions.EMULSION_MODEL_CURVE_DESCRIPTION,
         schema=schema.emulsion_model_curve_description_schema,
-        is_sequence=False
+        is_sequence=False,
     ),
     "BipDescription": AlfacaseTestConfig(
         description_expected=filled_case_descriptions.BIP_DESCRIPTION,

--- a/tests/alfacase/test_alfacase_to_case.py
+++ b/tests/alfacase/test_alfacase_to_case.py
@@ -140,6 +140,11 @@ def alfacase_to_case_helper(tmp_path):
 
 
 ALFACASE_TEST_CONFIG_MAP = {
+    "EmulsionModelCurveDescription": AlfacaseTestConfig(
+        description_expected=filled_case_descriptions.EMULSION_MODEL_CURVE_DESCRIPTION,
+        schema=schema.emulsion_model_curve_description_schema,
+        is_sequence=False
+    ),
     "BipDescription": AlfacaseTestConfig(
         description_expected=filled_case_descriptions.BIP_DESCRIPTION,
         schema=schema.bip_description_schema,

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_EmulsionModelCurveDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_EmulsionModelCurveDescription_.txt
@@ -1,0 +1,20 @@
+.. rubric:: Definitions
+
+.. tab:: CaseDescription
+
+    .. parsed-literal::
+
+        class EmulsionModelCurveDescription
+            domain: \ :class:`Array <barril.units.Array>`\  = Array(dimensionless, [0.0], m3/m3)
+            image: \ :class:`Array <barril.units.Array>`\  = Array(dimensionless, [1.0], -)
+
+.. tab:: Schema
+
+    .. parsed-literal::
+
+            domain:  # optional
+                values: [number]
+                unit: string
+            image:  # optional
+                values: [number]
+                unit: string

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PhysicsDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_PhysicsDescription_.txt
@@ -18,8 +18,8 @@
             emulsion_pal_rhodes_phi_rel_100: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.765, '-', 'dimensionless')
             emulsion_woelflin_a: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(4.2, '-', 'dimensionless')
             emulsion_woelflin_b: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(2.5, '-', 'dimensionless')
-            emulsion_table_based_rel_visc_curve: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(-, m3/m3)[(1.0, 0.0)]
-            emulsion_relative_viscosity_tuning_factor: \ :class:`Curve <barril.curve.curve.Curve>`\  = Curve(-, m3/m3)[(1.0, 0.0)]
+            emulsion_table_based_rel_visc_curve: \ :class:`EmulsionModelCurveDescription <EmulsionModelCurveDescription>`\  = EmulsionModelCurveDescription()
+            emulsion_relative_viscosity_tuning_factor: \ :class:`EmulsionModelCurveDescription <EmulsionModelCurveDescription>`\  = EmulsionModelCurveDescription()
             emulsion_droplet_size_model: \ :class:`EmulsionDropletSizeModelType <alfasim_sdk._internal.constants.EmulsionDropletSizeModelType>`\  = EmulsionDropletSizeModelType.ModelDefault
             emulsion_inversion_point_model: \ :class:`EmulsionInversionPointModelType <alfasim_sdk._internal.constants.EmulsionInversionPointModelType>`\  = EmulsionInversionPointModelType.ModelDefault
             emulsion_inversion_water_cut: \ :class:`Scalar <barril.units.Scalar>`\  = Scalar(0.4, 'm3/m3', 'volume per volume')
@@ -49,20 +49,8 @@
             emulsion_woelflin_b:  # optional
                 value: number
                 unit: string
-            emulsion_table_based_rel_visc_curve:  # optional
-                image:
-                    values: [number]
-                    unit: string
-                domain:
-                    values: [number]
-                    unit: string
-            emulsion_relative_viscosity_tuning_factor:  # optional
-                image:
-                    values: [number]
-                    unit: string
-                domain:
-                    values: [number]
-                    unit: string
+            emulsion_table_based_rel_visc_curve: \ :class:`emulsion_model_curve_description_schema <EmulsionModelCurveDescription>`\  # optional
+            emulsion_relative_viscosity_tuning_factor: \ :class:`emulsion_model_curve_description_schema <EmulsionModelCurveDescription>`\  # optional
             emulsion_droplet_size_model: \ :class:`EmulsionDropletSizeModelType <alfasim_sdk._internal.constants.EmulsionDropletSizeModelType>`\  # optional
             emulsion_inversion_point_model: \ :class:`EmulsionInversionPointModelType <alfasim_sdk._internal.constants.EmulsionInversionPointModelType>`\  # optional
             emulsion_inversion_water_cut:  # optional

--- a/tests/alfacase/test_generate_case_schema.py
+++ b/tests/alfacase/test_generate_case_schema.py
@@ -489,6 +489,7 @@ def test_get_cases_class():
         "WallLayerDescription",
         "WellDescription",
         "XAndYDescription",
+        "EmulsionModelCurveDescription",
     }
     assert (
         obtained == expected

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -79,6 +79,13 @@ cv_table_description_schema = Map(
     }
 )
 
+emulsion_model_curve_description_schema = Map(
+    {
+        Optional("domain"): Map({"values": Seq(Float()), "unit": Str()}),
+        Optional("image"): Map({"values": Seq(Float()), "unit": Str()}),
+    }
+)
+
 environment_property_description_schema = Map(
     {
         "position": Map({"value": Float(), "unit": Str()}),
@@ -380,41 +387,6 @@ packer_description_schema = Map(
         "name": Str(),
         "position": Map({"value": Float(), "unit": Str()}),
         Optional("material_above"): Str(),
-    }
-)
-
-physics_description_schema = Map(
-    {
-        Optional("hydrodynamic_model"): Enum(['hydrodynamic_model_2_fields', 'hydrodynamic_model_4_fields', 'hydrodynamic_model_3_layers_gas_oil_water', 'hydrodynamic_model_5_fields_solid', 'hydrodynamic_model_5_fields_water', 'hydrodynamic_model_5_fields_co2', 'hydrodynamic_model_3_layers_no_bubble_gas_oil_water', 'hydrodynamic_model_3_layers_water_with_co2', 'hydrodynamic_model_3_layers_7_fields_gas_oil_water', 'hydrodynamic_model_3_layers_9_fields_gas_oil_water']),
-        Optional("simulation_regime"): Enum(['simulation_regime_transient', 'simulation_regime_steady_state']),
-        Optional("energy_model"): Enum(['no_model', 'global_model', 'layers_model']),
-        Optional("solids_model"): Enum(['no_model', 'thomas1965_equilibrium', 'mills1985_equilibrium', 'santamaria2010_equilibrium', 'from_plugin']),
-        Optional("solids_model_plugin_id"): Str(),
-        Optional("initial_condition_strategy"): Enum(['constant', 'steady_state', 'restart']),
-        Optional("restart_filepath"): Str(),
-        Optional("keep_former_results"): Bool(),
-        Optional("emulsion_model_enabled"): Bool(),
-        Optional("emulsion_relative_viscosity_model"): Enum(['model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'pal_rhodes1989', 'ronningsen1995', 'volumetric_weight', 'woelflin_1942', 'barnea_mizrahi1976', 'table_based', 'from_plugin']),
-        Optional("emulsion_pal_rhodes_phi_rel_100"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_woelflin_a"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_woelflin_b"): Map({"value": Float(), "unit": Str()}),
-        Optional("emulsion_table_based_rel_visc_curve"): Map(
-            {
-                "image": Map({"values": Seq(Float()), "unit": Str()}),
-                "domain": Map({"values": Seq(Float()), "unit": Str()}),
-            }
-        ),
-        Optional("emulsion_relative_viscosity_tuning_factor"): Map(
-            {
-                "image": Map({"values": Seq(Float()), "unit": Str()}),
-                "domain": Map({"values": Seq(Float()), "unit": Str()}),
-            }
-        ),
-        Optional("emulsion_droplet_size_model"): Enum(['model_default', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012']),
-        Optional("emulsion_inversion_point_model"): Enum(['model_default', 'brauner_and_ullmann_2002', 'brinkman1952_and_yeh1964', 'constant']),
-        Optional("emulsion_inversion_water_cut"): Map({"value": Float(), "unit": Str()}),
-        Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
-        Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
     }
 )
 
@@ -957,6 +929,31 @@ leak_equipment_description_schema = Map(
         Optional("target_location"): Enum(['main', 'annulus', 'not_defined']),
         Optional("backflow"): Bool(),
         Optional("backpressure"): Map({"value": Float(), "unit": Str()}),
+    }
+)
+
+physics_description_schema = Map(
+    {
+        Optional("hydrodynamic_model"): Enum(['hydrodynamic_model_2_fields', 'hydrodynamic_model_4_fields', 'hydrodynamic_model_3_layers_gas_oil_water', 'hydrodynamic_model_5_fields_solid', 'hydrodynamic_model_5_fields_water', 'hydrodynamic_model_5_fields_co2', 'hydrodynamic_model_3_layers_no_bubble_gas_oil_water', 'hydrodynamic_model_3_layers_water_with_co2', 'hydrodynamic_model_3_layers_7_fields_gas_oil_water', 'hydrodynamic_model_3_layers_9_fields_gas_oil_water']),
+        Optional("simulation_regime"): Enum(['simulation_regime_transient', 'simulation_regime_steady_state']),
+        Optional("energy_model"): Enum(['no_model', 'global_model', 'layers_model']),
+        Optional("solids_model"): Enum(['no_model', 'thomas1965_equilibrium', 'mills1985_equilibrium', 'santamaria2010_equilibrium', 'from_plugin']),
+        Optional("solids_model_plugin_id"): Str(),
+        Optional("initial_condition_strategy"): Enum(['constant', 'steady_state', 'restart']),
+        Optional("restart_filepath"): Str(),
+        Optional("keep_former_results"): Bool(),
+        Optional("emulsion_model_enabled"): Bool(),
+        Optional("emulsion_relative_viscosity_model"): Enum(['model_default', 'taylor1932', 'brinkman1952', 'mooney1951a', 'mooney1951b', 'pal_rhodes1989', 'ronningsen1995', 'volumetric_weight', 'woelflin_1942', 'barnea_mizrahi1976', 'table_based', 'from_plugin']),
+        Optional("emulsion_pal_rhodes_phi_rel_100"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_woelflin_a"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_woelflin_b"): Map({"value": Float(), "unit": Str()}),
+        Optional("emulsion_table_based_rel_visc_curve"): emulsion_model_curve_description_schema,
+        Optional("emulsion_relative_viscosity_tuning_factor"): emulsion_model_curve_description_schema,
+        Optional("emulsion_droplet_size_model"): Enum(['model_default', 'hinze1955', 'sleicher1962', 'brauner2001', 'boxall2012']),
+        Optional("emulsion_inversion_point_model"): Enum(['model_default', 'brauner_and_ullmann_2002', 'brinkman1952_and_yeh1964', 'constant']),
+        Optional("emulsion_inversion_water_cut"): Map({"value": Float(), "unit": Str()}),
+        Optional("flash_model"): Enum(['hydrocarbon_only', 'hydrocarbon_and_water']),
+        Optional("correlations_package"): Enum(['correlation_package_classical', 'correlation_package_alfasim', 'correlation_package_isdb_tests']),
     }
 )
 

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -646,7 +646,6 @@ TIME_OPTIONS_DESCRIPTION = case_description.TimeOptionsDescription(
 EMULSION_MODEL_CURVE_DESCRIPTION = case_description.EmulsionModelCurveDescription(
     image=Array([1.0, 1.5, 2.0, 1.0], "-"),
     domain=Array([0.0, 0.4, 0.6, 1.0], "m3/m3"),
-
 )
 
 PHYSICS_DESCRIPTION = case_description.PhysicsDescription(

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -643,6 +643,12 @@ TIME_OPTIONS_DESCRIPTION = case_description.TimeOptionsDescription(
     minimum_time_for_steady_state_stop=Scalar(7, "s"),
 )
 
+EMULSION_MODEL_CURVE_DESCRIPTION = case_description.EmulsionModelCurveDescription(
+    image=Array([1.0, 1.5, 2.0, 1.0], "-"),
+    domain=Array([0.0, 0.4, 0.6, 1.0], "m3/m3"),
+
+)
+
 PHYSICS_DESCRIPTION = case_description.PhysicsDescription(
     hydrodynamic_model=constants.HydrodynamicModelType.ThreeLayersNineFieldsGasOilWater,
     simulation_regime=constants.SimulationRegimeType.SteadyState,
@@ -654,10 +660,7 @@ PHYSICS_DESCRIPTION = case_description.PhysicsDescription(
     correlations_package=constants.CorrelationPackageType.Alfasim,
     emulsion_model_enabled=True,
     emulsion_relative_viscosity_model=constants.EmulsionRelativeViscosityModelType.Brinkman1952,
-    emulsion_relative_viscosity_tuning_factor=Curve(
-        image=Array([1.0, 1.5, 2.0, 1.0], "-"),
-        domain=Array([0.0, 0.4, 0.6, 1.0], "m3/m3"),
-    ),
+    emulsion_relative_viscosity_tuning_factor=EMULSION_MODEL_CURVE_DESCRIPTION,
     emulsion_droplet_size_model=constants.EmulsionDropletSizeModelType.Brauner2001,
     emulsion_inversion_point_model=constants.EmulsionInversionPointModelType.Brinkman1952AndYeh1964,
     flash_model=constants.FlashModel.HydrocarbonOnly,


### PR DESCRIPTION
In AlfasimCore was change the emusion model from TupleTable to SubjectTable. For this reason, these changes in sdk is needed to maintain the backarwad capability.

ASIM-5167