### PR TITLE
Fix method `to_curve`

### DIFF
--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -193,7 +193,10 @@ def to_curve(
         return Curve(image, domain)
     elif isinstance(value, Curve):
         if value.GetLength() == 0:
-            return Curve(image=Array([1.0], value.GetImage().unit), domain=Array([1.0], value.GetDomain().unit))
+            return Curve(
+                image=Array([1.0], value.GetImage().unit),
+                domain=Array([1.0], value.GetDomain().unit),
+            )
         return value
 
     message = prepare_error_message(

--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -192,6 +192,8 @@ def to_curve(
         )
         return Curve(image, domain)
     elif isinstance(value, Curve):
+        if value.GetLength() == 0:
+            return Curve(image=Array([1.0], value.GetImage().unit), domain=Array([1.0], value.GetDomain().unit))
         return value
 
     message = prepare_error_message(

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -1088,6 +1088,13 @@ def test_to_curve():
     assert to_curve(curve) is curve
 
 
+    image = Array("length", [], "m")
+    domain = Array("time", [], "s")
+    curve = Curve(image, domain)
+    fixed_curve = to_curve(curve)
+    assert fixed_curve.image.GetValues() == [1.0]
+
+
 @pytest.mark.parametrize(
     "attrib_creator, default",
     [

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -1087,7 +1087,6 @@ def test_to_curve():
 
     assert to_curve(curve) is curve
 
-
     image = Array("length", [], "m")
     domain = Array("time", [], "s")
     curve = Curve(image, domain)


### PR DESCRIPTION
This PR fix the method `to_curve` to return a curve if the length of `value` parameter is 0.

Tests from `test_configure_case_from_study.py` were crashing because the `GetAsCurve()` was returning nothing and the method `to_curve` did not know how to handle it.