### PR TITLE
Release 0.14.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+
+0.14.1 (2023-04-26)
+===================
+
+* Hot fix release, loosing pin requirements for `barril`.
+
 0.14.0 (2022-07-19)
 ===================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,5 +42,5 @@ install_requires =
     ruamel.yaml<0.16.13
     boltons
     Click>=7.0
-    barril>=1.13,<1.14
+    barril>=1.13,<2.0
     pluggy>=0.13.0


### PR DESCRIPTION
As discussed internally, the pin for barril is too restrict.

Loose it so we can use 0.14 with more recent `barril` versions.