### PR TITLE
Reverting changes from PR 297

### DIFF
--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -3316,28 +3316,6 @@ class PhysicsDescription:
         default=constants.CorrelationPackageType.Classical
     )
 
-    @emulsion_inversion_water_cut.validator
-    def _validate_inversion_point_water_cut(self, attribute, value):
-        assert (
-            isinstance(value, Scalar)
-            and value.GetCategory() == "volume per volume"
-            and 0.0 <= value.GetValue("m3/m3") <= 1.0
-        ), "Invalid inversion point water-cut"
-
-    @emulsion_relative_viscosity_tuning_factor.validator
-    def _validate_emulsion_relative_viscosity_tuning_factor(self, attribute, value):
-        domain = value.GetDomain()
-        assert domain.GetCategory() == "volume per volume", "Invalid water-cut category"
-        domain_values = np.asarray(domain.GetValues("m3/m3"))
-        assert (
-            np.min(domain_values) >= 0.0 and np.max(domain_values) <= 1.0
-        ), "Invalid water-cut values"
-        image = value.GetImage()
-        assert (
-            image.GetCategory() == "dimensionless"
-            and np.min(image.GetValues("-")) >= 1.0e-5
-        ), "Tuning factor cannot be lower than 1e-5"
-
 
 @attr.s()
 class TimeOptionsDescription:

--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -192,11 +192,6 @@ def to_curve(
         )
         return Curve(image, domain)
     elif isinstance(value, Curve):
-        if value.GetLength() == 0:
-            return Curve(
-                image=Array([1.0], value.GetImage().unit),
-                domain=Array([1.0], value.GetDomain().unit),
-            )
         return value
 
     message = prepare_error_message(

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -1087,12 +1087,6 @@ def test_to_curve():
 
     assert to_curve(curve) is curve
 
-    image = Array("length", [], "m")
-    domain = Array("time", [], "s")
-    curve = Curve(image, domain)
-    fixed_curve = to_curve(curve)
-    assert fixed_curve.image.GetValues() == [1.0]
-
 
 @pytest.mark.parametrize(
     "attrib_creator, default",


### PR DESCRIPTION
Reference issue: ASIM-5237

Reference PR: https://github.com/ESSS/alfasim-sdk/pull/297

Empty `Curves` should be treated in right places, not generating data arbitrarily.