### PR TITLE
Update readthedocs config to use build.os

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,15 +1,18 @@
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+  apt_packages:
+    - graphviz
 
 python:
-    version: 3.7
-    install:
-        -   method: pip
-            path: .
-        -   requirements: docs/requirements.txt
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt
 
 sphinx:
-    configuration: docs/source/conf.py
-    fail_on_warning: true
+  configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,9 @@
-sphinx==4.0.2
-breathe==4.30.0
+sphinx
+breathe
 sphinx-click
 sphinx-invoke
 pydata-sphinx-theme
 sphinx-inline-tabs
 sphinx-copybutton
 sphinx_togglebutton
-graphviz
 colorama
-# Pin docutils because of circular include warnings (see #193)
-docutils==0.16

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ rst_prolog = """
 
 """
 
-language = None
+language = "en"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "breathe/*"]
 
 # -- Options for HTML output -------------------------------------------------
@@ -110,7 +110,6 @@ html_logo = "_static/images/logo-alfasim.svg"
 
 html_theme_options = {
     "github_url": "https://github.com/esss/alfasim-sdk",
-    "google_analytics_id": "UA-149094345-1",
 }
 html_static_path = ["_static"]
 html_css_files = [


### PR DESCRIPTION
Previously, the config was using build.image, but this configuration will be no longer available after October, 16th 2023. See [this announcement](https://blog.readthedocs.com/use-build-os-config/)

Notice that I've added `graphviz` dependency to the `apt_packages` in the `readthedocs.yml` and removed from the `requirements.txt` because using `pip` the binary seems to not be available anymore, and the `graphviz` documentation suggests that it's preferable to use the package manager.

Finally, I tried changing the python version to be a newer one like 3.10, but there was some problems with the pinned version of sphinx and I opt to leave it to python 3.7 for now.

Close #317
ASIM-5369