### PR TITLE
Release 0.18.0: remove pins for `strictyaml`, py310, drop old Pythons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -55,7 +55,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.10"
 
     - name: Build Package
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,23 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest]
-        include:
-          # non-matrix listed runs (python 3.6 is not supported with ubuntu-latest).
-          - python-version: 3.6
-            os: ubuntu-20.04
-            env: "py36"
-          - python-version: 3.6
-            os: windows-latest
-            env: "py36"
-          # "env" for matrix listed python runs.
-          - python-version: 3.7
-            env: "py37"
-          - python-version: 3.8
-            env: "py38"
-          - python-version: 3.9
-            env: "py39"
 
     steps:
     - uses: actions/checkout@v2
@@ -53,14 +38,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox codecov
     - name: Run tests
-      run: tox -e ${{matrix.env}}
+      run: tox -e py
     - name: Upload codecov
       run: codecov -t  ${{secrets.CODECOV_TOKEN}} -X gcov -f coverage.xml
 
   deploy:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && github.repository == 'ESSS/alfasim-sdk'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: test
 
@@ -70,12 +55,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Build Package
       run: |
-        python -m pip install --upgrade pip wheel setuptools
-        python setup.py sdist bdist_wheel
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade build
+        python -m build
 
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ History
 0.18.0 (2023-10-13)
 ===================
 
+* Added support for Python 3.10, 3.11, and 3.12.
+* Dropped support for EOL Python 3.6 and 3.7.
 * Remove pins for ``strictyaml`` and no longer require ``ruamel.yaml``.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ History
 0.18.0 (2023-10-13)
 ===================
 
-* Added support for Python 3.10, 3.11, and 3.12.
+* Added support for Python 3.10.
 * Dropped support for EOL Python 3.6 and 3.7.
 * Remove pins for ``strictyaml`` and no longer require ``ruamel.yaml``.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,11 @@
 History
 =======
 
-0.18.0 (UNRELEASED)
+0.18.0 (2023-10-13)
 ===================
+
+* Remove pins for ``strictyaml`` and no longer require ``ruamel.yaml``.
+
 
 0.17.0 (2023-09-01)
 ===================

--- a/dev-environment.devenv.yml
+++ b/dev-environment.devenv.yml
@@ -19,7 +19,6 @@ dependencies:
   - pytest-mock
   - python
   - python-hookman
-  - ruamel.yaml
   - sphinx-click
   - toposort
   - tox

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,5 +8,4 @@ pytest
 pytest-cov
 pytest-mock
 pytest-regressions
-ruamel.yaml
 toposort

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: 3.12
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,8 @@ setup_requires =
 install_requires =
     python-hookman
     typing_inspect
-    strictyaml
+    # 1.4.3 seems to be the first version which bundles ruamel.
+    strictyaml>=1.4.3
     boltons
     Click>=7.0
     barril>=1.13,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,11 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options.entry_points]
 console_scripts =
@@ -31,7 +32,7 @@ package_dir =
     =src
 include_package_data = True
 
-python_requires = >=3.6
+python_requires = >=3.8
 zip_safe = no
 setup_requires =
     setuptools>=40.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,8 +38,7 @@ setup_requires =
 install_requires =
     python-hookman
     typing_inspect
-    strictyaml<1.4
-    ruamel.yaml<0.16.13
+    strictyaml
     boltons
     Click>=7.0
     barril>=1.13,<2.0

--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Top-level package for alfasim-sdk."""
 import pluggy
 

--- a/src/alfasim_sdk/_internal/alfacase/alfatable.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfatable.py
@@ -33,7 +33,7 @@ def load_pvt_model_table_parameters_description_from_alfatable(
     """
     Load the content from the alfatable in the given file_path. The validation is turned off due to performance issues.
     """
-    from ruamel.yaml.main import YAML
+    from strictyaml.ruamel.main import YAML
     from barril.units import Scalar
     import numpy as np
 

--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -346,7 +346,7 @@ def attrib_instance_list(type_: type) -> attr._make._CountingAttr:
     Create a new attr attribute with validator for the given type_
     All attributes created are expected to be List of the given type_
 
-    :param validator_type:
+    :param type_:
         Inform which type(s) the List should validate.
         When not defined the param type_ will be used the type to be validated.
 

--- a/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
@@ -82,7 +82,7 @@ def _convert_value_to_valid_alfacase_format(
         )
 
     if isinstance(value, list) and all(
-        (isinstance(item, np.ndarray) and item.ndim == 1 for item in value)
+        isinstance(item, np.ndarray) and item.ndim == 1 for item in value
     ):
         return [
             format_list(
@@ -92,7 +92,7 @@ def _convert_value_to_valid_alfacase_format(
             for np_array in value
         ]
 
-    if isinstance(value, list) and all((isinstance(item, Array) for item in value)):
+    if isinstance(value, list) and all(isinstance(item, Array) for item in value):
         return [
             {"values": [str(i) for i in item.values], "unit": item.unit}
             for item in value

--- a/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
@@ -38,21 +38,7 @@ def format_list(values: List[Any], *, enable_flow_style: bool = False):
     For more details check:
     https://stackoverflow.com/questions/63364894/how-to-dump-only-lists-with-flow-style-with-pyyaml-or-ruamel-yaml
     """
-    import strictyaml
-
-    # The strictyaml version used by alfasim has ruamel vendored
-    # making it unable to work with the "non-vendored" ruamel version.
-    # The strictyaml version obtained with pip to run test on github
-    # uses a non vendored version of ruamel.
-    # By now we use by default here the vendored ruamel with a fallback
-    # to the original ruamel.
-    # When updating alfasim's strictyaml we probably should review this hack.
-    if hasattr(strictyaml, "ruamel"):
-        comments = strictyaml.ruamel.comments
-    else:
-        import ruamel
-
-        comments = ruamel.yaml.comments
+    from strictyaml.ruamel import comments
 
     retval = comments.CommentedSeq(values)
 

--- a/src/alfasim_sdk/_internal/alfacase/generate_schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_schema.py
@@ -72,7 +72,7 @@ def str_to_alfacase_schema(type_: type, indent: int) -> str:
 
 
 def is_attrs(type_: type) -> bool:
-    return any((hasattr(i, "__attrs_attrs__") for i in flatten([type_])))
+    return any(hasattr(i, "__attrs_attrs__") for i in flatten([type_]))
 
 
 def attrs_to_alfacase_schema(type_: type, indent: int) -> str:

--- a/src/alfasim_sdk/_internal/units.py
+++ b/src/alfasim_sdk/_internal/units.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 
 
-@lru_cache()
+@lru_cache
 def register_units() -> None:
     """
     Register new categories for Barril and limit the number of units shown to users.

--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -11,7 +11,7 @@ from colorama import Style
 from hookman.hookman_generator import HookManGenerator
 from invoke import Exit
 from invoke import task
-from ruamel.yaml import YAML
+from strictyaml.ruamel import YAML
 
 
 def print_message(

--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -253,7 +253,7 @@ def update(ctx):
 
 @task()
 def install_plugin(ctx, install_dir=None):
-    """
+    r"""
     Install a plugin to ``install_dir`` folder.
 
     If absent, the ``install_dir`` will be assumed to be ``$HOME/.alfasim_plugins`` on linux
@@ -311,7 +311,7 @@ def install_plugin(ctx, install_dir=None):
 
 @task()
 def uninstall_plugin(ctx, install_dir=None):
-    """
+    r"""
     Remove plugin from install folder.
 
     If absent, the ``install_dir`` will be assumed to be ``$HOME/.alfasim_plugins`` on linux
@@ -349,7 +349,7 @@ def uninstall_plugin(ctx, install_dir=None):
 
 @task()
 def reinstall_plugin(ctx, package_name, install_dir=None):
-    """
+    r"""
     Remove, package and install an specified plugin to install_dir
 
     If absent, the ``install_dir`` will be assumed to be ``$HOME/.alfasim_plugins`` on linux

--- a/tests/alfacase/test_alfacase_to_case.py
+++ b/tests/alfacase/test_alfacase_to_case.py
@@ -8,8 +8,8 @@ import pytest
 import strictyaml
 from barril.units import Array
 from barril.units import Scalar
-from ruamel.yaml.comments import CommentedMap
 from strictyaml import YAML
+from strictyaml.ruamel.comments import CommentedMap
 
 from ..common_testing.alfasim_sdk_common_testing import filled_case_descriptions
 from ..common_testing.alfasim_sdk_common_testing import get_acme_tab_file_path

--- a/tests/plugins/test_models.py
+++ b/tests/plugins/test_models.py
@@ -74,7 +74,7 @@ def test_invalid_attribute():
         class ModelPrivateAttribute:  # pylint: disable=unused-variable
             _invalid_attribute = ValidType(caption="invalid")
 
-    class Invalid(object):
+    class Invalid:
         pass
 
     error_msg = (

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -29,8 +29,7 @@ def new_plugin_dir(tmp_path: Path) -> Path:
             f"--author-name={plugin_id.upper()}",
             f"--dst={tmp_path}",
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
 
     assert result.stdout.decode("utf-8") == ""
@@ -129,8 +128,7 @@ def test_update_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
     assert plugin_hook_spec_h_path.stat().st_size == 0
     result = subprocess.run(
         [f"{invoke_cmd}", "update"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     assert result.stdout.decode("utf-8") == ""
     assert result.stderr.decode("utf-8") == ""

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -8,7 +8,6 @@ from zipfile import ZipFile
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from ruamel.yaml import YAML
 
 from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
 
@@ -358,6 +357,8 @@ def test_clean_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
     sys.platform != "win32", reason="msvc task is only available on windows"
 )
 def test_msvc_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
+    from strictyaml.ruamel import YAML
+
     monkeypatch.chdir(new_plugin_dir)
 
     artifacts_dir = new_plugin_dir / "artifacts"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py36, py37, py38, py39, linting
+envlist = py{38,39,310}
 
 [testenv]
 download=true
@@ -14,10 +14,3 @@ deps=
 commands =
     inv cog --check
     pytest --basetemp={envtmpdir} --cov={envsitepackagesdir}/alfasim_sdk --cov=tests --cov-report=xml --color=yes {posargs}
-
-
-[testenv:linting]
-skip_install = True
-basepython = python3.6
-deps = pre-commit>=1.11.0
-commands = pre-commit run --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps=
 
 commands =
     inv cog --check
-    pytest --basetemp={envtmpdir} --cov={envsitepackagesdir}/alfasim_sdk --cov=tests --cov-report=xml
+    pytest --basetemp={envtmpdir} --cov={envsitepackagesdir}/alfasim_sdk --cov=tests --cov-report=xml --color=yes {posargs}
 
 
 [testenv:linting]


### PR DESCRIPTION
As a library, we should not use hardpins like this unless with a very good reason (preferably documented if a restriction is required).

* Removed explict dependency to `ruamel`, using instead the bundled library from `strictyaml` when needed.

* Removed old Python 3.6 and 3.7.
* Added support for Python 3.10.

Note: tried to add support for Python 3.11 and Python 3.12, however got a strange recursion error, we will need to investigate this later.

Closes #329.
