### PR TITLE
Add ruamel.yaml dependency

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -7,6 +7,7 @@ dependencies:
   - boltons
   - click
   - h5py
+  - ruamel.yaml
   - typing_inspect
 
 environment:


### PR DESCRIPTION
This dependency is needed by the default_tasks.py file, but it was not included in the environment.devenv.yml, previously it was just included in the dev-environment.devenv.yml.

DCC-132