### PR TITLE
Update invoke tasks and AlfasimRunner fixture

### DIFF
--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -63,6 +63,7 @@ def get_msvc_cmake_generator(msvc_compiler: str) -> str:
 # =============================================================
 @task(
     help={
+        "cmake_extra_args": "Extra arguments that will be passed to cmake",
         "debug": "Compile in debug mode",
         "clean": "Remove previous build directory",
     }
@@ -171,11 +172,11 @@ def _get_hook_specs_file_path() -> Path:
 
 @task(
     help={
-        "package-name": "Name of the package.",
+        "package-name": "Name of the package. If empty, the package-name will be assumed to be the pluginid",
         "dst": "A path to where the output package should be created.",
     }
 )
-def package_only(ctx, package_name, dst=os.getcwd()):
+def package_only(ctx, package_name="", dst=os.getcwd()):
     """
     Generate a `<package_name>.hmplugin` file with all the content from the directory
     assets and artifacts.
@@ -195,6 +196,9 @@ def package_only(ctx, package_name, dst=os.getcwd()):
         get_extras_default_required_version,
     )
 
+    plugin_id = str(plugin_dir.name)
+    if not package_name:
+        package_name = plugin_id
     package_name_suffix = f"sdk-{get_current_version()}"
     extras_defaults = {
         EXTRAS_REQUIRED_VERSION_KEY: get_extras_default_required_version()
@@ -210,23 +214,26 @@ def package_only(ctx, package_name, dst=os.getcwd()):
 
 @task(
     help={
-        "package-name": "Name of the package.",
+        "package-name": "Name of the package. If empty, the package-name will be assumed to be the plugin_id",
         "dst": "A path to where the output package should be created.",
+        "debug": "Compile in debug mode",
+        "clean": "Remove previous build directory",
+        "cmake_extra_args": "Extra arguments that will be passed to cmake",
     }
 )
-def package(ctx, package_name, dst=os.getcwd()):
+def package(
+    ctx, package_name="", dst=os.getcwd(), debug=False, clean=False, cmake_extra_args=""
+):
     """
     Create a new `<package-name>.hmplugin` file containing all the necessary files.
 
     This command will first call `invoke compile` command to generate the shared library, and after that, the plugin
     package will be generated with all the content available from the directory assets and artifacts.
 
-    By default, the `package` command will assume that the plugin project is the current directory and the generated file
-    will be placed also in the current directory.
-
-    In order to change that, it's possible to use the options `plugin-dir` and `dst`
+    The `package` command will assume that the plugin project is the directory that
+    contains the ``tasks.py`` file and the generated file will be placed also in the current directory.
     """
-    compile(ctx)
+    compile(ctx, debug=debug, clean=clean, cmake_extra_args=cmake_extra_args)
     package_only(ctx, package_name=package_name, dst=dst)
 
 

--- a/src/alfasim_sdk/testing/fixtures.py
+++ b/src/alfasim_sdk/testing/fixtures.py
@@ -16,7 +16,7 @@ from _pytest.compat import assert_never
 from _pytest.monkeypatch import MonkeyPatch
 
 from alfasim_sdk import convert_alfacase_to_description
-from alfasim_sdk import convert_description_to_alfacase
+from alfasim_sdk import generate_alfacase_file
 from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
 from alfasim_sdk._internal.alfacase.case_description import CaseDescription
 from alfasim_sdk._internal.alfacase.case_description_attributes import DescriptionError
@@ -147,11 +147,8 @@ class AlfasimRunnerFixture:
         self.check_not_run()
         self.check_base_case_is_loaded()
 
-        alfacase = convert_description_to_alfacase(self._case)
-        project_folder = self.project_folder
-
         self.alfacase_data_folder.mkdir()
-        self.alfacase_file.write_text(alfacase, encoding="utf-8")
+        generate_alfacase_file(self._case, self.alfacase_file)
 
         try:
             self._run_simulator(
@@ -161,7 +158,7 @@ class AlfasimRunnerFixture:
                     f"--alfacase-file={str(self.alfacase_file)}",
                     f"--number-of-threads={number_of_threads}",
                 ],
-                cwd=project_folder,
+                cwd=self.project_folder,
             )
         except CalledProcessError as error:
 

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -118,6 +118,28 @@ def test_package_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
     assert package_filename.is_file()
 
 
+def test_package_task_empty_package_name(
+    new_plugin_dir: Path, monkeypatch: MonkeyPatch
+):
+    monkeypatch.chdir(new_plugin_dir)
+
+    package_dir_old = new_plugin_dir / "package"
+    package_dir_old.mkdir(exist_ok=True, parents=True)
+    subprocess.run(
+        [
+            f"{invoke_cmd}",
+            "package",
+        ],
+    )
+
+    from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
+
+    os_type = "win" if os.sys.platform == "win32" else "linux"
+    curr_sdk_version = get_current_version()
+    package_filename = Path(f"acme-1.0.0-sdk-{curr_sdk_version}-{os_type}64.hmplugin")
+    assert package_filename.is_file()
+
+
 def test_update_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
     monkeypatch.chdir(new_plugin_dir)
     plugin_src_folder = new_plugin_dir / "src"


### PR DESCRIPTION
This PR consists of two small improvements:

- Update compile and package tasks' flags to forward the arguments from one to the other.
  - Update some documentation of the tasks.
  - Make `package-name` option of the package task optional, since we can infer this from plugin-id attribute
- Use the function `generate_alfacase_file` in the AlfasimRunnerFixture to be more concise.
 
ASIM-5261