### PR TITLE
Allow user plugins to import from other modules inside it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 0.19.0 (UNRELEASED)
 ===================
 
+* Added support for user plugins have multiple python source files, the "user plugin entry point" logic is unchanged, but extra python code could be placed in `alfasim_sdk_plugins.<plugins_id>` and be imported at runtime;
+
+
 0.18.0 (2023-10-13)
 ===================
 

--- a/src/alfasim_sdk/_internal/cli.py
+++ b/src/alfasim_sdk/_internal/cli.py
@@ -68,22 +68,28 @@ def new(dst, caption, plugin_id, author_name, author_email):
 
     .. code-block:: bash
 
-        \---myplugin
-        |   CMakeLists.txt
-        |   tasks.py
-        |
-        +---assets
-        |       plugin.yaml
-        |       README.md
-        |
-        \---src
+        <dest>
+        \---<plugin_id>
             |   CMakeLists.txt
-            |   hook_specs.h
-            |   myplugin.cpp
+            |   tasks.py
             |
-            \---python
-                    myplugin.py
+            +---assets
+            |       plugin.yaml
+            |       README.md
+            |
+            \---src
+                |   CMakeLists.txt
+                |   hook_specs.h
+                |   <plugin_id>.cpp
+                |
+                \---python
+                    |   <plugin_id>.py
+                    |
+                    \---alfasim_sdk_plugins
+                        \---<plugin_id>
+                                __init__.py
 
+    Any python code placed in ``alfasim_sdk_plugins/<plugin_id>`` is importable by using ``import alfasim_sdk_plugins.<plugin_id>.<my_extra_module>``.
     """
     dst = Path(dst)
     hook_specs_file_path = _get_hook_specs_file_path()
@@ -112,7 +118,11 @@ def new(dst, caption, plugin_id, author_name, author_email):
     source_folder = dst / plugin_id / "src"
     python_folder = source_folder / "python"
     python_folder.mkdir()
-    Path(python_folder / f"{plugin_id}.py").touch()
+    (python_folder / f"{plugin_id}.py").touch()
+
+    importable_module = python_folder / "alfasim_sdk_plugins" / plugin_id
+    importable_module.mkdir(parents=True)
+    (importable_module / "__init__.py").touch()
 
     # remove compile.py created by hookman
     compile_file = dst / plugin_id / "compile.py"

--- a/src/alfasim_sdk_plugins/__init__.py
+++ b/src/alfasim_sdk_plugins/__init__.py
@@ -1,0 +1,13 @@
+"""
+This is not supposed to be a real package.
+It is the namespace of user plugins and is manipulated by the user plugins infrastructure.
+
+The documentation explicitly states that the `namespace packages`_' __path__ is read-only and
+automatically updated if the `sys.path` changes (also `PEP-420`_), initial tests show that it
+is not read-only and was not magically updated, but better to write code to the spec when possible.
+
+Using this to avoid polluting the global `sys.path` with random user plugin stuff.
+
+.. `namespace packages`_: https://docs.python.org/3.10/reference/import.html#namespace-packages
+.. `PEP-420`_: https://peps.python.org/pep-0420/
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,8 +27,8 @@ def test_command_new(tmp_path):
     assert result.exit_code == 0
 
     plugin_dir = tmp_path / "acme"
-    assets_dir = plugin_dir / "assets"
-    compile_file = plugin_dir / "tasks.py"
     assert plugin_dir.is_dir()
-    assert assets_dir.is_dir()
-    assert compile_file.is_file()
+    assert (plugin_dir / "assets").is_dir()
+    assert (plugin_dir / "tasks.py").is_file()
+    importable_package = plugin_dir / "src/python/alfasim_sdk_plugins/acme"
+    assert (importable_package / "__init__.py").is_file()


### PR DESCRIPTION
Now user plugins can have a namespace package named
`alfasim_sdk_plugins` (located in the `<plugin_id>/src/python` folder)
inside of which the plugin specific python source could be placed an
later imported.
At runtime alfasim/alfasim-sdk will import a root module also named
`alfasim_sdk_plugins` and manually edit `__path__` so the python's
import machinery look into the user plugins' namespace packages without
the need to further edit `sys.path` and cause possible import name
clashes.

ASIM-5419