### PR TITLE
Set correct category for void_fractions array

### DIFF
--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -647,8 +647,8 @@ class TablePumpDescription:
     .. include:: /alfacase_definitions/list_of_unit_for_volume_fraction.txt
     .. include:: /alfacase_definitions/list_of_unit_for_pressure.txt
     """
-    speeds = attrib_array(Array([0.0] * 12 + [400.0] * 12 + [600.0] * 12, 'rpm'), category="angle per time")
-    void_fractions = attrib_array(Array(([0.0] * 6 + [0.1] * 6) * 3, '-'))
+    speeds = attrib_array(Array("angle per time", [0.0] * 12 + [400.0] * 12 + [600.0] * 12, 'rpm'))
+    void_fractions = attrib_array(Array("volume fraction", ([0.0] * 6 + [0.1] * 6) * 3, '-'))
     flow_rates = attrib_array(Array([0.0, 0.05, 0.1, 0.15, 0.2, 0.3] * 6, 'm3/s'))
 
     pressure_boosts = attrib_array(Array(

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -417,7 +417,7 @@ RESERVOIR_INFLOW_DESCRIPTION = case_description.ReservoirInflowEquipmentDescript
 )
 TABLE_PUMP_DESCRIPTION = case_description.TablePumpDescription(
     speeds=Array([0.0] * 4 + [500.0] * 4, "rpm"),
-    void_fractions=Array("volume fraction", [0.0] * 4 + [0.1] * 4, "-"),
+    void_fractions=Array([0.0] * 4 + [0.1] * 4, "-"),
     flow_rates=Array([1.0] * 4 + [0.05] * 4, "m3/s"),
     pressure_boosts=Array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], "bar"),
     heads=Array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], "m") * 1.0e5 / (9.8 * 1000.0),


### PR DESCRIPTION
ASIM-5451

This fixes the issue with exporting and then importing an alfacase containing a pump.

I don't quite know how to test this. I haven't found a simple way to reproduce the problem (that doesn't involve launching the application, exporting and then importing the alfacase, then clicking the pump).