### PR TITLE
Add release data to last version changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 0.20.0 (UNRELEASED)
 ===================
 
-0.19.0 (UNRELEASED)
+0.19.0 (2024-01-02)
 ===================
 
 * Added support for user plugins have multiple python source files, the "user plugin entry point" logic is unchanged, but extra python code could be placed in `alfasim_sdk_plugins.<plugins_id>` and be imported at runtime;


### PR DESCRIPTION
This is already on master. It was only required to resolve a conflict between the release branch and the master, so we can merge then.