### PR TITLE
Add a HOOK capable of updating plugin variables only once at the end of the time step computation

### DIFF
--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -83,8 +83,8 @@ is called, but if it is running the `first time step`
 :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_ON_FIRST_TIMESTEP<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_on_first_timestep>`
 is called before. It is necessary because usually during the `first time step` some initialization tasks are needed. Then,
 if the plugin needs to initialize with some value that is different from the initial ``nan`` value, this hook is the place to do that.
-For situation where computations inside hooks are extremely heavy, there is also the possibility to only do the secondary
-variable once at the end of the timestep by using :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_TIME_EXPLICIT<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit>`
+For situations where computations inside hooks are extremely heavy, there is also the possibility to only do the secondary
+variable update once at the end of the timestep by using :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_TIME_EXPLICIT<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit>`
 
 .. note::
     Different from plugin internal data, the secondary variables registered by plugins are allocated, deallocated and

--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -95,6 +95,8 @@ variable update once at the end of the timestep by using :py:func:`HOOK_UPDATE_P
 
 .. autofunction:: alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_on_first_timestep
 
+.. autofunction:: alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit
+
 The |alfasim|'s Solver is divided in two *non-linear solvers* solvers that will solve different group of equations. The first one is
 the `hydrodynamic solver` which solves the Mass Conservation of fields, Momentum Conservation of layers and Energy Conservation
 equations all together for all elements in the network. The second one is the `Tracer Solver` which solves the Mass Conservation

--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -83,8 +83,7 @@ is called, but if it is running the `first time step`
 :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_ON_FIRST_TIMESTEP<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_on_first_timestep>`
 is called before. It is necessary because usually during the `first time step` some initialization tasks are needed. Then,
 if the plugin needs to initialize with some value that is different from the initial ``nan`` value, this hook is the place to do that.
-For situations where computations inside hooks are extremely heavy, there is also the possibility to only do the secondary
-variable update once at the end of the timestep by using :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_TIME_EXPLICIT<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit>`
+Another possibility is to update secondary variables explicitly on timestep. For that :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_TIME_EXPLICIT<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit>` can be used and it will be called once at the end of the timestep. This hook is important in situations where the secondary variable doesn't affect the solution or when secondary variable computations are extremely heavy, in which computational time would be prohibited.
 
 .. note::
     Different from plugin internal data, the secondary variables registered by plugins are allocated, deallocated and

--- a/docs/source/plugins/06_solver_hooks.rst
+++ b/docs/source/plugins/06_solver_hooks.rst
@@ -83,6 +83,8 @@ is called, but if it is running the `first time step`
 :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_ON_FIRST_TIMESTEP<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_on_first_timestep>`
 is called before. It is necessary because usually during the `first time step` some initialization tasks are needed. Then,
 if the plugin needs to initialize with some value that is different from the initial ``nan`` value, this hook is the place to do that.
+For situation where computations inside hooks are extremely heavy, there is also the possibility to only do the secondary
+variable once at the end of the timestep by using :py:func:`HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES_TIME_EXPLICIT<alfasim_sdk._internal.hook_specs.update_plugins_secondary_variables_time_explicit>`
 
 .. note::
     Different from plugin internal data, the secondary variables registered by plugins are allocated, deallocated and

--- a/src/alfasim_sdk/_internal/hook_specs.py
+++ b/src/alfasim_sdk/_internal/hook_specs.py
@@ -142,7 +142,7 @@ def update_plugins_secondary_variables(ctx: "void*") -> "int":
             int errcode = -1;
             int size_U = -1;
             int size_E = -1;
-            int liq_id = -1;
+            int oil_id = -1;
             errcode = alfasim_sdk_api.get_field_id(
                 ctx, &oil_id, "oil");
             double* vel;
@@ -152,7 +152,7 @@ def update_plugins_secondary_variables(ctx: "void*") -> "int":
                 TimestepScope::CURRENT
             }
             errcode = alfasim_sdk_api.get_simulation_array(
-                ctx, &vel, (char*) "U", Fields_OnFaces, liq_id, &size_U);
+                ctx, &vel, (char*) "U", Fields_OnFaces, oil_id, &size_U);
             double* kinetic_energy;
             char* name = "kinetic_energy_of_oil";
             int global_idx = 0;


### PR DESCRIPTION
[DCC-208](https://esss.atlassian.net/browse/DCC-208l)

Add a HOOK capable of updating plugin variables only once at the end of the time step computation (not on each step of Newton method - which is done by regular HOOK_UPDATE_PLUGINS_SECONDARY_VARIABLES)

[DCC-208]: https://esss.atlassian.net/browse/DCC-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ