### PR TITLE
Allowing velocity as mm/a

### DIFF
--- a/docs/source/alfacase_definitions/list_of_unit_for_velocity.txt
+++ b/docs/source/alfacase_definitions/list_of_unit_for_velocity.txt
@@ -13,4 +13,5 @@
     :"m/h": metres/hour
     :"m/min": meter per minute
     :"m/s": metres/second
+    :"mm/a": millimetres/year
     :"mm/s": millimetres/second

--- a/src/alfasim_sdk/_internal/units.py
+++ b/src/alfasim_sdk/_internal/units.py
@@ -116,6 +116,7 @@ def register_units() -> None:
     velocity_units.remove("mm/min")
     velocity_units.remove("in/d")
     velocity_units.remove("in/h")
+    velocity_units.append("mm/a")
     db.AddCategory(
         "velocity", quantity_type="velocity", valid_units=velocity_units, override=True
     )

--- a/tests/alfacase/test_generate_list_of_units/test_generate_list_of_units_velocity_.txt
+++ b/tests/alfacase/test_generate_list_of_units/test_generate_list_of_units_velocity_.txt
@@ -13,4 +13,5 @@
     :"m/h": metres/hour
     :"m/min": meter per minute
     :"m/s": metres/second
+    :"mm/a": millimetres/year
     :"mm/s": millimetres/second


### PR DESCRIPTION
Allowing velocity as mm/a because it is used in scaling plugin for Scaling growth velocity 

[DCC-196](https://esss.atlassian.net/browse/DCC-196)

[DCC-196]: https://esss.atlassian.net/browse/DCC-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ