### PR TITLE
Add pipe roughness to API's get_simulation_array

### DIFF
--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -463,6 +463,7 @@ DLL_EXPORT int get_state_variable_array(
     - `"D"`: Pipe Inner Diameter [m]
     - `"A"`: Cross-sectional Area in each control volume [m2]
     - `"theta"`: Inclination of each control volume [rad]
+    - `"ks"`: Pipe roughness. Only available for FACE GridScope  [m]
     - `"dx"`: Control Volume Length along the Pipe Axis [m]
     - `"dv"`: Volume of the control volume [m3]
     - `"D_eff"`: Effective Pipe Inner Diameter, considering the internal deposit layers [m]


### PR DESCRIPTION
Added to be used by corrosion plugin's mixture model calculation.

The nomenclature `ks` was chosen instead of `ε` because it's already being used by `get_ucm_friction_factor_input_variable` hook

DCC-182
