### PR TITLE
Add parametric vars map to History Matching results metadata

### DIFF
--- a/src/alfasim_sdk/result_reader/aggregator.py
+++ b/src/alfasim_sdk/result_reader/aggregator.py
@@ -229,6 +229,9 @@ class HistoryMatchingMetadata:
     :ivar objective_functions:
         Map of observed curve id to a dict of Quantity of Interest data, populated with keys
         'trend_id' and 'property_id'. This represents the setup for this HM analysis.
+    :ivar parametric_vars:
+        Map of parametric vars to the values that represents the analysis, with all existent vars.
+        Values are either the optimal values (deterministic) or the base values (probabilistic).
     :ivar result_directory:
         The directory in which the result is saved.
     """
@@ -275,12 +278,18 @@ class HistoryMatchingMetadata:
     objective_functions: Dict[str, Dict[str, str]] = attr.ib(
         validator=attr.validators.instance_of(Dict)
     )
+    parametric_vars: Dict[str, float] = attr.ib(
+        validator=attr.validators.instance_of(Dict)
+    )
     result_directory: Path = attr.ib(validator=attr.validators.instance_of(Path))
 
     @classmethod
     def empty(cls, result_directory: Path) -> Self:
         return cls(
-            hm_items={}, objective_functions={}, result_directory=result_directory
+            hm_items={},
+            objective_functions={},
+            parametric_vars={},
+            result_directory=result_directory,
         )
 
     @classmethod
@@ -308,13 +317,15 @@ class HistoryMatchingMetadata:
             if len(loaded_metadata) == 0:
                 return cls.empty(result_directory=result_directory)
 
-            objective_functions = list(loaded_metadata.values())[0][
-                "objective_functions"
-            ]
+            some_item_metadata = list(loaded_metadata.values())[0]
+
+            objective_functions = some_item_metadata["objective_functions"]
+            parametric_vars = some_item_metadata["parametric_vars"]
 
             return cls(
                 hm_items=map_data(loaded_metadata),
                 objective_functions=objective_functions,
+                parametric_vars=parametric_vars,
                 result_directory=result_directory,
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import shutil
 import textwrap
 from pathlib import Path
 from typing import List
-from typing import Sequence
-from typing import Tuple
 
 import h5py
 import numpy as np
@@ -275,7 +273,6 @@ def _create_and_populate_hm_result_file(
     result_dir: Path,
     result: np.ndarray,
     dataset_key: str,
-    limits: Sequence[Tuple[float, float]],
 ) -> None:
     result_dir.mkdir(parents=True, exist_ok=True)
     result_filepath = result_dir / "result"
@@ -295,22 +292,25 @@ def _create_and_populate_hm_result_file(
             "observed_curve_1": {"trend_id": "trend_1", "property_id": "holdup"},
             "observed_curve_2": {"trend_id": "trend_2", "property_id": "pressure"},
         }
+        parametric_vars = {"mg": 0.5, "mo": 4.0}
 
         fake_meta = {
             "parametric_var_1": {
                 "parametric_var_id": "parametric_var_1",
                 "parametric_var_name": "mg",
-                "min_value": limits[0][0],
-                "max_value": limits[0][1],
+                "min_value": 0.0,
+                "max_value": 1.0,
                 "objective_functions": objective_functions,
+                "parametric_vars": parametric_vars,
                 "data_index": 0,
             },
             "parametric_var_2": {
                 "parametric_var_id": "parametric_var_2",
                 "parametric_var_name": "mo",
-                "min_value": limits[1][0],
-                "max_value": limits[1][1],
+                "min_value": 2.5,
+                "max_value": 7.5,
                 "objective_functions": objective_functions,
+                "parametric_vars": parametric_vars,
                 "data_index": 1,
             },
         }
@@ -332,13 +332,11 @@ def hm_probabilistic_results_dir(datadir: Path) -> Path:
     probabilistic_result = np.array(
         [[0.1, 0.22, 1.0, 0.8, 0.55], [3.0, 6.0, 5.1, 4.7, 6.3]]
     )
-    limits = [(0.0, 1.0), (2.5, 7.5)]
 
     _create_and_populate_hm_result_file(
         result_dir=result_dir,
         result=probabilistic_result,
         dataset_key=HISTORY_MATCHING_PROBABILISTIC_DSET_NAME,
-        limits=limits,
     )
 
     return result_dir
@@ -353,13 +351,11 @@ def hm_deterministic_results_dir(datadir: Path) -> Path:
 
     result_dir = datadir / "main-HM-deterministic"
     deterministic_result = np.array([0.1, 3.2])
-    limits = [(0.0, 1.0), (2.5, 7.5)]
 
     _create_and_populate_hm_result_file(
         result_dir=result_dir,
         result=deterministic_result,
         dataset_key=HISTORY_MATCHING_DETERMINISTIC_DSET_NAME,
-        limits=limits,
     )
 
     return result_dir

--- a/tests/results/test_aggregator.py
+++ b/tests/results/test_aggregator.py
@@ -394,7 +394,11 @@ def test_read_history_matching_result_metadata(
     metadata = read_history_matching_metadata(hm_results_dir)
 
     assert metadata.result_directory == hm_results_dir
-    items_meta = metadata.hm_items
+    assert metadata.objective_functions == {
+        "observed_curve_1": {"trend_id": "trend_1", "property_id": "holdup"},
+        "observed_curve_2": {"trend_id": "trend_2", "property_id": "pressure"},
+    }
+    assert metadata.parametric_vars == {"mg": 0.5, "mo": 4.0}
 
     expected_meta1 = HistoryMatchingMetadata.HMItem(
         parametric_var_id="parametric_var_1",
@@ -412,6 +416,7 @@ def test_read_history_matching_result_metadata(
         data_index=1,
     )
 
+    items_meta = metadata.hm_items
     assert items_meta["parametric_var_1"] == expected_meta1
     assert items_meta["parametric_var_2"] == expected_meta2
 


### PR DESCRIPTION
Do so because results readers may need to know the info "var name X value" of the rest of the parametric vars (i.e. the disabled ones, that may or may not be dependent on the enabled/overriden vars) to fetch the results.

Related: https://github.com/ESSS/alfasim/pull/541.

ASIM-5586