### PR TITLE
Improve debug of user plugins

### DIFF
--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -209,7 +209,7 @@ def _get_hook_specs_file_path() -> Path:
         "dst": "A path to where the output package should be created.",
     }
 )
-def package_only(ctx, package_name="", dst=os.getcwd()):
+def package_only(ctx, package_name="", dst=""):
     """
     Generate a `<package_name>.hmplugin` file with all the content from the directory
     assets and artifacts.
@@ -220,7 +220,12 @@ def package_only(ctx, package_name="", dst=os.getcwd()):
 
     # Set to the plugin root, where the tasks.py is located in the plugin structure
     plugin_dir = Path(ctx.config._project_prefix)
-    dst = Path(dst)
+
+    if dst:
+        dst = Path(dst)
+    else:
+        dst = plugin_dir
+
     hook_specs_file_path = _get_hook_specs_file_path()
     hm = HookManGenerator(hook_spec_file_path=hook_specs_file_path)
     from alfasim_sdk._internal.constants import EXTRAS_REQUIRED_VERSION_KEY
@@ -255,7 +260,7 @@ def package_only(ctx, package_name="", dst=os.getcwd()):
     }
 )
 def package(
-    ctx, package_name="", dst=os.getcwd(), debug=False, clean=False, cmake_extra_args=""
+    ctx, package_name="", dst="", debug=False, clean=False, cmake_extra_args=""
 ):
     """
     Create a new `<package-name>.hmplugin` file containing all the necessary files.

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -392,7 +392,9 @@ def test_msvc_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
     assert spec_file.is_file()
     assert spec_file.stat().st_size > 0
 
-    subprocess.run([f"{invoke_cmd}", "msvc"])
+    extra_args = "--cmake-extra-args=-DTEST=ON"
+
+    subprocess.run([f"{invoke_cmd}", "msvc", extra_args])
 
     msvc_dir = new_plugin_dir / "msvc"
     sln_file = msvc_dir / (plugin_id + ".sln")


### PR DESCRIPTION
Improve the support of the debug of user plugins by letting the user provide a `cmake-extra-args` flag to the msvc task.

Also, fix an error prune default value for the `package-only` task's `dst` parameter

DCC-173