### PR TITLE
Make get_wall_material_names return material name for one layer id

### DIFF
--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -881,34 +881,37 @@ DLL_EXPORT int get_wall_properties(void* ctx, double** prop_values, const char* 
 
 
 /*!
-    Gets the names of the materials presented in each layer of the wall for a given control volume.
-    The names will be given as an array of char pointers.
+    Gets the name of the material for a given control volume and layer.
+    The names will be given as char pointer.
 
     Example of usage:
 
     ~~~~~{.cpp}
 
-                                               [material_name_4]
-      [material_name_3]                        [material_name_3]
-      [material_name_2]   [material_name_2]    [material_name_2]
-      [material_name_1]   [material_name_1]    [material_name_1]
-      [material_name_0]   [material_name_0]    [material_name_0]
-              |                   |                   |
-    --[control_volume_1]--[control_volume_2]--[control_volume_3]-->  (Pipe)
+                                                           [material_name_4_cv_3]
+    [material_name_3_cv_1]                                 [material_name_3_cv_3]
+    [material_name_2_cv_1]      [material_name_2_cv_2]     [material_name_2_cv_3]
+    [material_name_1_cv_1]      [material_name_1_cv_2]     [material_name_1_cv_3]
+    [material_name_0_cv_1]      [material_name_0_cv_2]     [material_name_0_cv_3]
+              |                           |                          |
+    --[control_volume_1]----------[control_volume_2]---------[control_volume_3]--------->  (Pipe)
     ~~~~~
 
     ~~~~~{.cpp}
-    errcode = get_wall_material_names(
-        ctx, &material_names_in_wall, control_volume_id, &size_wall);
+    int layer_id = 1
+    int control_volume = control_volume_2
+
+    errcode = get_wall_material_name(
+        ctx, &material_name, control_volume_id, layer_id);
     ~~~~~
 
     @param[in] ctx ALFAsim's plugins context.
-    @param[out] material_names_in_wall Names of the material presented in the wall.
+    @param[out] material_name Names of the material presented in the wall.
     @param[in] control_volume_id Control volume id.
-    @param[out] size Size of the `material_names_in_wall` array.
+    @param[in] layer_id Layer id.
     @return An #error_code value.
 */
-DLL_EXPORT int get_wall_material_names(void* ctx, char*** material_names_in_wall, int control_volume_id, int* size);
+DLL_EXPORT int get_wall_material_name(void* ctx, char** material_name, int control_volume_id, int layer_id);
 
 /*!
     Gets the information if the each layer in the wall is fluid or not for a given control volume.

--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -906,7 +906,7 @@ DLL_EXPORT int get_wall_properties(void* ctx, double** prop_values, const char* 
     ~~~~~
 
     @param[in] ctx ALFAsim's plugins context.
-    @param[out] material_name Names of the material presented in the wall.
+    @param[out] material_name Name of the material presented in the wall.
     @param[in] control_volume_id Control volume id.
     @param[in] layer_id Layer id.
     @return An #error_code value.

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
@@ -81,11 +81,11 @@ using get_wall_properties_func = int (*) (
     int control_volume_id,
     int* size
     );
-using get_wall_material_names_func = int (*) (
+using get_wall_material_name_func = int (*) (
     void* ctx,
-    char*** wall_names,
+    char** wall_name,
     int control_volume_id,
-    int* size
+    int layer_id
     );
 using get_wall_material_type_func = int (*) (
     void* ctx,
@@ -179,7 +179,7 @@ struct ALFAsimSDK_API {
     get_wall_interfaces_temperature_func get_wall_interfaces_temperature;
 
     get_wall_properties_func get_wall_properties;
-    get_wall_material_names_func get_wall_material_names;
+    get_wall_material_name_func get_wall_material_name;
     get_wall_material_type_func get_wall_material_type;
 
     get_input_variable_func get_ucm_friction_factor_input_variable;

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
@@ -78,7 +78,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_simulation_quantity = (get_simulation_quantity_func)dlsym(api->handle, "get_simulation_quantity");
     api->get_wall_interfaces_temperature = (get_wall_interfaces_temperature_func)dlsym(api->handle, "get_wall_interfaces_temperature");
     api->get_wall_properties = (get_wall_properties_func)dlsym(api->handle, "get_wall_properties");
-    api->get_wall_material_names = (get_wall_material_names_func)dlsym(api->handle, "get_wall_material_names");
+    api->get_wall_material_name = (get_wall_material_name_func)dlsym(api->handle, "get_wall_material_name");
     api->get_wall_material_type = (get_wall_material_type_func)dlsym(api->handle, "get_wall_material_type");
     api->get_flow_pattern = (get_flow_pattern_func)dlsym(api->handle, "get_flow_pattern");
     api->get_liqliq_flow_pattern = (get_flow_pattern_func)dlsym(api->handle, "get_liqliq_flow_pattern");

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
@@ -102,7 +102,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_simulation_quantity = (get_simulation_quantity_func)GetProcAddress(api->handle, "get_simulation_quantity");
     api->get_wall_interfaces_temperature = (get_wall_interfaces_temperature_func)GetProcAddress(api->handle, "get_wall_interfaces_temperature");
     api->get_wall_properties = (get_wall_properties_func)GetProcAddress(api->handle, "get_wall_properties");
-    api->get_wall_material_names = (get_wall_material_names_func)GetProcAddress(api->handle, "get_wall_material_names");
+    api->get_wall_material_name = (get_wall_material_name_func)GetProcAddress(api->handle, "get_wall_material_name");
     api->get_wall_material_type = (get_wall_material_type_func)GetProcAddress(api->handle, "get_wall_material_type");
     api->get_flow_pattern = (get_flow_pattern_func)GetProcAddress(api->handle, "get_flow_pattern");
     api->get_liqliq_flow_pattern = (get_flow_pattern_func)GetProcAddress(api->handle, "get_liqliq_flow_pattern");


### PR DESCRIPTION
PR description:
- There was a bug at get_wall_material_names which was returning the wall names for all layers at once with char** (The char** doesn't know how many steps should be done to find the next wall name, since it does not have information about the length of the name). 
Solution: make the get_wall_material_name only return one wall name at once, by making the user provide the layer_id.