### PR TITLE
Drop the workaround to allow paths with non ascii chars

### DIFF
--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -7,6 +7,8 @@ dependencies:
   - boltons
   - click
   - h5py
+  # Supports non-ascii paths (ASIM-5880).
+  - hdf5 >= 1.10
   - typing_inspect
 
 environment:


### PR DESCRIPTION
In recent hdf5 versions the old problem with non ascii paths apper to be fixed. A test to check this support have been added.

ASIM-5880

Related PR (commit) in alfasim: https://github.com/ESSS/alfasim/pull/731 (https://github.com/ESSS/alfasim/pull/731/commits/98f610fed968b8cc7b3dec45ce7702058575b5ed)