### PR TITLE
Migrate to ruff

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# List of revisions that can be ignored with git-blame(1).
+#
+# See `blame.ignoreRevsFile` in git-config(1) to enable it by default, or
+# use it with `--ignore-revs-file` manually with git-blame.
+#
+# To "install" it:
+#
+#   git config --local blame.ignoreRevsFile .gitblameignore
+
+# run ruff format
+0b1812b80088fee1931f7f4d19046da56f662199

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,20 +10,13 @@ exclude: |
 default_language_version:
     python: python3.10
 repos:
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.9.4
     hooks:
-    -   id: reorder-python-imports
-        args:
-            - --application-directories=.:src
--   repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-    -   id: black
-        args:
-            - --safe
-            - --quiet
-        language_version: python3
+    -   id: ruff
+        args: [--fix]
+    -   id: ruff-format
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,30 @@ requires = [
   "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+target-version = "py310"
+src = [
+    "src",
+    "tests",
+]
+format.docstring-code-format = true
+lint.select = ['E4', 'E7', 'E9', 'F', 'I']
+lint.ignore = [
+    "E402",
+    "E711",
+    "E712",
+    "E721",
+    "E722",
+    "E731",
+    "E741",
+    "F401",
+    "F403",
+    "F405",
+    "F507",
+    "F601",
+    "F722",
+    "F811",
+    "F821",
+    "F841",
+]

--- a/src/alfasim_sdk/__init__.py
+++ b/src/alfasim_sdk/__init__.py
@@ -1,4 +1,5 @@
 """Top-level package for alfasim-sdk."""
+
 import pluggy
 
 from alfasim_sdk._internal import version
@@ -21,340 +22,252 @@ def get_alfasim_sdk_api_path():
     """
     Return the directory that contains the alfasim_sdk_api with the header files
     """
-    from alfasim_sdk._internal import hook_specs
     from pathlib import Path
+
+    from alfasim_sdk._internal import hook_specs
 
     return str(Path(hook_specs.__file__).parents[1])
 
 
 # CLI:
-from alfasim_sdk._internal.cli import console_main
-
-# ALFACase: Descriptions
-from alfasim_sdk._internal.alfacase.case_description import AnnulusDescription
-from alfasim_sdk._internal.alfacase.case_description import BipDescription
-from alfasim_sdk._internal.alfacase.case_description import AlfasimVersionInfo
-from alfasim_sdk._internal.alfacase.case_description import CaseDescription
-from alfasim_sdk._internal.alfacase.case_description import CaseOutputDescription
-from alfasim_sdk._internal.alfacase.case_description import CasingDescription
-from alfasim_sdk._internal.alfacase.case_description import CasingSectionDescription
-from alfasim_sdk._internal.alfacase.case_description import CompositionDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    CompressorEquipmentDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    CompressorPressureTableDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import CvTableDescription
-from alfasim_sdk._internal.alfacase.case_description import EnvironmentDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    EnvironmentPropertyDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import EquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import AnnulusEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import CombinedFluidDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    CompositionalFluidDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import FormationDescription
-from alfasim_sdk._internal.alfacase.case_description import FormationLayerDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    GasLiftValveEquipmentDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    HeatSourceEquipmentDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import HeavyComponentDescription
-from alfasim_sdk._internal.alfacase.case_description import IPRCurveDescription
-from alfasim_sdk._internal.alfacase.case_description import IPRModelsDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialConditionsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialPressuresDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialTemperaturesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialTracersMassFractionsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialVelocitiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InitialVolumeFractionsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InternalNodePropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import LeakEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    LengthAndElevationDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import LightComponentDescription
-from alfasim_sdk._internal.alfacase.case_description import LinearIPRDescription
-from alfasim_sdk._internal.alfacase.case_description import VogelIPRDescription
-from alfasim_sdk._internal.alfacase.case_description import FetkovichIPRDescription
-from alfasim_sdk._internal.alfacase.case_description import ForchheimerIPRDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    MassSourceEquipmentDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    MassSourceNodePropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import MaterialDescription
-from alfasim_sdk._internal.alfacase.case_description import NodeDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    NumericalOptionsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import OpenHoleDescription
-from alfasim_sdk._internal.alfacase.case_description import PackerDescription
-from alfasim_sdk._internal.alfacase.case_description import PhysicsDescription
-from alfasim_sdk._internal.alfacase.case_description import PigEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import PipeDescription
-from alfasim_sdk._internal.alfacase.case_description import PipeSegmentsDescription
-from alfasim_sdk._internal.alfacase.case_description import PluginDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    PressureContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    InternalReferencePluginTableColumn,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    TracerReferencePluginTableColumn,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    PressureNodePropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import ProfileDescription
-from alfasim_sdk._internal.alfacase.case_description import ProfileOutputDescription
-from alfasim_sdk._internal.alfacase.case_description import PumpEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelCompositionalDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelCombinedDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelCorrelationDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import PvtModelsDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelPtTableParametersDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelConstantPropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    PvtModelPhTableParametersDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReferencedPressureContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReferencedTemperaturesContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReferencedTracersMassFractionsContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReferencedVelocitiesContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReferencedVolumeFractionsContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ReservoirInflowEquipmentDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    SeparatorNodePropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import SpeedCurveDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    SurgeVolumeOptionsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import TableIPRDescription
-from alfasim_sdk._internal.alfacase.case_description import TablePumpDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    TemperaturesContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import TimeOptionsDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    TracerModelConstantCoefficientsDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import TracersDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    TracersMassFractionsContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    TrendsOutputDescription,
-    PositionalPipeTrendDescription,
-    OverallPipeTrendDescription,
-    GlobalTrendDescription,
-    EquipmentTrendDescription,
-    SeparatorTrendDescription,
-    ControllerTrendDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import TubingDescription
-from alfasim_sdk._internal.alfacase.case_description import ValveEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    VelocitiesContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    VolumeFractionsContainerDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import WallDescription
-from alfasim_sdk._internal.alfacase.case_description import WallLayerDescription
-from alfasim_sdk._internal.alfacase.case_description import WellDescription
-from alfasim_sdk._internal.alfacase.case_description import XAndYDescription
-
-from alfasim_sdk._internal.alfacase.case_description import (
-    ControllerNodePropertiesDescription,
-)
-from alfasim_sdk._internal.alfacase.case_description import (
-    ControllerInputSignalPropertiesDescription,
-    ControllerOutputSignalPropertiesDescription,
-)
-
 # ALFACase: Utilities
-from alfasim_sdk._internal.alfacase.alfacase import convert_alfacase_to_description
-from alfasim_sdk._internal.alfacase.alfacase import convert_description_to_alfacase
-from alfasim_sdk._internal.alfacase.alfacase import generate_alfacase_file
-from alfasim_sdk._internal.alfacase.alfatable import generate_alfatable_file
+from alfasim_sdk._internal.alfacase.alfacase import (
+    convert_alfacase_to_description,
+    convert_description_to_alfacase,
+    generate_alfacase_file,
+)
 from alfasim_sdk._internal.alfacase.alfatable import (
+    generate_alfatable_file,
     load_pvt_model_table_parameters_description_from_alfatable,
 )
 
-# Constants
-from alfasim_sdk._internal.constants import BUBBLE_FIELD
-from alfasim_sdk._internal.constants import CompressorSpeedType
-from alfasim_sdk._internal.constants import ControllerType
-from alfasim_sdk._internal.constants import CorrelationsGasViscosity
-from alfasim_sdk._internal.constants import CorrelationsOilViscosity
-from alfasim_sdk._internal.constants import CorrelationPackage
-from alfasim_sdk._internal.constants import CorrelationPackageType
-from alfasim_sdk._internal.constants import CorrelationsSurfaceTension
-from alfasim_sdk._internal.constants import DEFAULT_TEMPERATURE_IN_K
-from alfasim_sdk._internal.constants import DrainageRateMode
-from alfasim_sdk._internal.constants import DROPLET_FIELD
-from alfasim_sdk._internal.constants import EmulsionModelType
-from alfasim_sdk._internal.constants import EmulsionRelativeViscosityModelType
-from alfasim_sdk._internal.constants import EmulsionDropletSizeModelType
-from alfasim_sdk._internal.constants import EmulsionInversionPointModelType
-from alfasim_sdk._internal.constants import EnergyModel
-from alfasim_sdk._internal.constants import EnergyModelPrimaryVariable
-from alfasim_sdk._internal.constants import EquationOfStateType
-from alfasim_sdk._internal.constants import EquipmentAttachmentLocation
-from alfasim_sdk._internal.constants import EvaluationStrategyType
-from alfasim_sdk._internal.constants import EXTRAS_REQUIRED_VERSION_KEY
-from alfasim_sdk._internal.constants import FlashModel
-from alfasim_sdk._internal.constants import FlowDirection
-from alfasim_sdk._internal.constants import FlowPatternModel
-from alfasim_sdk._internal.constants import FLUID_GAS
-from alfasim_sdk._internal.constants import FLUID_OIL
-from alfasim_sdk._internal.constants import FLUID_PHASE_NAMES
-from alfasim_sdk._internal.constants import FLUID_WATER
-from alfasim_sdk._internal.constants import GAS_FIELD
-from alfasim_sdk._internal.constants import GAS_LAYER
-from alfasim_sdk._internal.constants import GAS_PHASE
-from alfasim_sdk._internal.constants import GasLiftValveOpeningType
-from alfasim_sdk._internal.constants import HydrodynamicModelType
-from alfasim_sdk._internal.constants import InitialConditionStrategyType
-from alfasim_sdk._internal.constants import InterpolationType
-from alfasim_sdk._internal.constants import LeakLocation
-from alfasim_sdk._internal.constants import LeakModel
-from alfasim_sdk._internal.constants import LeakType
-from alfasim_sdk._internal.constants import MassInflowSplitType
-from alfasim_sdk._internal.constants import MassSourceType
-from alfasim_sdk._internal.constants import MaterialType
-from alfasim_sdk._internal.constants import MultiInputType
-from alfasim_sdk._internal.constants import NodeCellType
-from alfasim_sdk._internal.constants import NonlinearSolverType
-from alfasim_sdk._internal.constants import OIL_FIELD
-from alfasim_sdk._internal.constants import OIL_LAYER
-from alfasim_sdk._internal.constants import OIL_PHASE
-from alfasim_sdk._internal.constants import OutputAttachmentLocation
-from alfasim_sdk._internal.constants import PigRoutingMode
-from alfasim_sdk._internal.constants import PigTrappingMode
-from alfasim_sdk._internal.constants import (
-    PipeEnvironmentHeatTransferCoefficientModelType,
+# ALFACase: Descriptions
+from alfasim_sdk._internal.alfacase.case_description import (
+    AlfasimVersionInfo,
+    AnnulusDescription,
+    AnnulusEquipmentDescription,
+    BipDescription,
+    CaseDescription,
+    CaseOutputDescription,
+    CasingDescription,
+    CasingSectionDescription,
+    CombinedFluidDescription,
+    CompositionalFluidDescription,
+    CompositionDescription,
+    CompressorEquipmentDescription,
+    CompressorPressureTableDescription,
+    ControllerInputSignalPropertiesDescription,
+    ControllerNodePropertiesDescription,
+    ControllerOutputSignalPropertiesDescription,
+    ControllerTrendDescription,
+    CvTableDescription,
+    EnvironmentDescription,
+    EnvironmentPropertyDescription,
+    EquipmentDescription,
+    EquipmentTrendDescription,
+    FetkovichIPRDescription,
+    ForchheimerIPRDescription,
+    FormationDescription,
+    FormationLayerDescription,
+    GasLiftValveEquipmentDescription,
+    GlobalTrendDescription,
+    HeatSourceEquipmentDescription,
+    HeavyComponentDescription,
+    InitialConditionsDescription,
+    InitialPressuresDescription,
+    InitialTemperaturesDescription,
+    InitialTracersMassFractionsDescription,
+    InitialVelocitiesDescription,
+    InitialVolumeFractionsDescription,
+    InternalNodePropertiesDescription,
+    InternalReferencePluginTableColumn,
+    IPRCurveDescription,
+    IPRModelsDescription,
+    LeakEquipmentDescription,
+    LengthAndElevationDescription,
+    LightComponentDescription,
+    LinearIPRDescription,
+    MassSourceEquipmentDescription,
+    MassSourceNodePropertiesDescription,
+    MaterialDescription,
+    NodeDescription,
+    NumericalOptionsDescription,
+    OpenHoleDescription,
+    OverallPipeTrendDescription,
+    PackerDescription,
+    PhysicsDescription,
+    PigEquipmentDescription,
+    PipeDescription,
+    PipeSegmentsDescription,
+    PluginDescription,
+    PositionalPipeTrendDescription,
+    PressureContainerDescription,
+    PressureNodePropertiesDescription,
+    ProfileDescription,
+    ProfileOutputDescription,
+    PumpEquipmentDescription,
+    PvtModelCombinedDescription,
+    PvtModelCompositionalDescription,
+    PvtModelConstantPropertiesDescription,
+    PvtModelCorrelationDescription,
+    PvtModelPhTableParametersDescription,
+    PvtModelPtTableParametersDescription,
+    PvtModelsDescription,
+    ReferencedPressureContainerDescription,
+    ReferencedTemperaturesContainerDescription,
+    ReferencedTracersMassFractionsContainerDescription,
+    ReferencedVelocitiesContainerDescription,
+    ReferencedVolumeFractionsContainerDescription,
+    ReservoirInflowEquipmentDescription,
+    SeparatorNodePropertiesDescription,
+    SeparatorTrendDescription,
+    SpeedCurveDescription,
+    SurgeVolumeOptionsDescription,
+    TableIPRDescription,
+    TablePumpDescription,
+    TemperaturesContainerDescription,
+    TimeOptionsDescription,
+    TracerModelConstantCoefficientsDescription,
+    TracerReferencePluginTableColumn,
+    TracersDescription,
+    TracersMassFractionsContainerDescription,
+    TrendsOutputDescription,
+    TubingDescription,
+    ValveEquipmentDescription,
+    VelocitiesContainerDescription,
+    VogelIPRDescription,
+    VolumeFractionsContainerDescription,
+    WallDescription,
+    WallLayerDescription,
+    WellDescription,
+    XAndYDescription,
 )
-from alfasim_sdk._internal.constants import PipeThermalModelType
-from alfasim_sdk._internal.constants import PipeThermalPositionInput
-from alfasim_sdk._internal.constants import PumpType
-from alfasim_sdk._internal.constants import PumpViscosityModel
-from alfasim_sdk._internal.constants import PumpThermalEfficiencyModel
-from alfasim_sdk._internal.constants import PVTCompositionalViscosityModel
-from alfasim_sdk._internal.constants import SeparatorGeometryType
-from alfasim_sdk._internal.constants import SimulationModeType
-from alfasim_sdk._internal.constants import SimulationRegimeType
-from alfasim_sdk._internal.constants import SOLID_PHASE
-from alfasim_sdk._internal.constants import SolidsModelType
-from alfasim_sdk._internal.constants import SurfaceTensionType
-from alfasim_sdk._internal.constants import SurgeVolumeTimeMode
-from alfasim_sdk._internal.constants import TableInputType
-from alfasim_sdk._internal.constants import TracerModelType
-from alfasim_sdk._internal.constants import ValveOpeningType
-from alfasim_sdk._internal.constants import ValveType
-from alfasim_sdk._internal.constants import WATER_DROPLET_IN_OIL_FIELD
-from alfasim_sdk._internal.constants import WATER_FIELD
-from alfasim_sdk._internal.constants import WATER_LAYER
-from alfasim_sdk._internal.constants import WATER_PHASE
-from alfasim_sdk._internal.constants import WellConnectionPort
-from alfasim_sdk._internal.constants import WellIndexPhaseType
-from alfasim_sdk._internal.constants import ForchheimerCoefficientsOption
-from alfasim_sdk._internal.constants import FluidMaterialConvectionCorrelation
+from alfasim_sdk._internal.cli import console_main
 
-
-# Plugins: Layouts imports
-from alfasim_sdk._internal.layout import tab
-from alfasim_sdk._internal.layout import tabs
-from alfasim_sdk._internal.layout import group
+# Constants
+from alfasim_sdk._internal.constants import (
+    BUBBLE_FIELD,
+    DEFAULT_TEMPERATURE_IN_K,
+    DROPLET_FIELD,
+    EXTRAS_REQUIRED_VERSION_KEY,
+    FLUID_GAS,
+    FLUID_OIL,
+    FLUID_PHASE_NAMES,
+    FLUID_WATER,
+    GAS_FIELD,
+    GAS_LAYER,
+    GAS_PHASE,
+    OIL_FIELD,
+    OIL_LAYER,
+    OIL_PHASE,
+    SOLID_PHASE,
+    WATER_DROPLET_IN_OIL_FIELD,
+    WATER_FIELD,
+    WATER_LAYER,
+    WATER_PHASE,
+    CompressorSpeedType,
+    ControllerType,
+    CorrelationPackage,
+    CorrelationPackageType,
+    CorrelationsGasViscosity,
+    CorrelationsOilViscosity,
+    CorrelationsSurfaceTension,
+    DrainageRateMode,
+    EmulsionDropletSizeModelType,
+    EmulsionInversionPointModelType,
+    EmulsionModelType,
+    EmulsionRelativeViscosityModelType,
+    EnergyModel,
+    EnergyModelPrimaryVariable,
+    EquationOfStateType,
+    EquipmentAttachmentLocation,
+    EvaluationStrategyType,
+    FlashModel,
+    FlowDirection,
+    FlowPatternModel,
+    FluidMaterialConvectionCorrelation,
+    ForchheimerCoefficientsOption,
+    GasLiftValveOpeningType,
+    HydrodynamicModelType,
+    InitialConditionStrategyType,
+    InterpolationType,
+    LeakLocation,
+    LeakModel,
+    LeakType,
+    MassInflowSplitType,
+    MassSourceType,
+    MaterialType,
+    MultiInputType,
+    NodeCellType,
+    NonlinearSolverType,
+    OutputAttachmentLocation,
+    PigRoutingMode,
+    PigTrappingMode,
+    PipeEnvironmentHeatTransferCoefficientModelType,
+    PipeThermalModelType,
+    PipeThermalPositionInput,
+    PumpThermalEfficiencyModel,
+    PumpType,
+    PumpViscosityModel,
+    PVTCompositionalViscosityModel,
+    SeparatorGeometryType,
+    SimulationModeType,
+    SimulationRegimeType,
+    SolidsModelType,
+    SurfaceTensionType,
+    SurgeVolumeTimeMode,
+    TableInputType,
+    TracerModelType,
+    ValveOpeningType,
+    ValveType,
+    WellConnectionPort,
+    WellIndexPhaseType,
+)
 
 # Plugins: Context
 from alfasim_sdk._internal.context import Context
 
+# Plugins: Layouts imports
+from alfasim_sdk._internal.layout import group, tab, tabs
+
 # Plugins: Models imports
-from alfasim_sdk._internal.models import container_model
-from alfasim_sdk._internal.models import data_model
+from alfasim_sdk._internal.models import container_model, data_model
 
 # Plugins: Status imports
-from alfasim_sdk._internal.status import WarningMessage
-from alfasim_sdk._internal.status import ErrorMessage
+from alfasim_sdk._internal.status import ErrorMessage, WarningMessage
 
 # Plugins: Types for configure_fields hook
-from alfasim_sdk._internal.types import AddField
-
 # Plugins: Types for configure_phases hook
-from alfasim_sdk._internal.types import AddPhase
-from alfasim_sdk._internal.types import UpdatePhase
-
 # Plugins: Types for configure_layers hook
-from alfasim_sdk._internal.types import AddLayer
-from alfasim_sdk._internal.types import UpdateLayer
-
 # Plugins: Types  for UI customization
-from alfasim_sdk._internal.types import BaseField
-from alfasim_sdk._internal.types import Boolean
-from alfasim_sdk._internal.types import Enum
-from alfasim_sdk._internal.types import FileContent
-from alfasim_sdk._internal.types import MultipleReference
-from alfasim_sdk._internal.types import Quantity
-from alfasim_sdk._internal.types import Reference
-from alfasim_sdk._internal.types import String
-from alfasim_sdk._internal.types import Table
-from alfasim_sdk._internal.types import TableColumn
-from alfasim_sdk._internal.types import TracerType
+from alfasim_sdk._internal.types import (
+    AddField,
+    AddLayer,
+    AddPhase,
+    BaseField,
+    Boolean,
+    Enum,
+    FileContent,
+    MultipleReference,
+    Quantity,
+    Reference,
+    String,
+    Table,
+    TableColumn,
+    TracerType,
+    UpdateLayer,
+    UpdatePhase,
+)
 
 # Plugins: Type for alfasim_get_additional_variables hook
-from alfasim_sdk._internal.variables import SecondaryVariable
-
 # Plugins: Constants used on SecondaryVariable
-from alfasim_sdk._internal.variables import Visibility
-from alfasim_sdk._internal.variables import Scope
-from alfasim_sdk._internal.variables import Type
-from alfasim_sdk._internal.variables import Location
+from alfasim_sdk._internal.variables import (
+    Location,
+    Scope,
+    SecondaryVariable,
+    Type,
+    Visibility,
+)
 
 __all__ = [
     "AddField",

--- a/src/alfasim_sdk/_internal/alfacase/alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase.py
@@ -79,6 +79,7 @@ def convert_description_to_alfacase(
     """
     import attr
     from strictyaml import YAML
+
     from .case_to_alfacase import convert_dict_to_valid_alfacase_format
 
     alfacase_description_dict = attr.asdict(alfacase_description, recurse=False)
@@ -96,7 +97,9 @@ def convert_alfacase_to_description(
     """
     Return a :class:`alfasim_sdk._internal.alfacase.case_description` with all information provided on file_yaml.
     """
-    from alfasim_sdk._internal.alfacase.alfacase_to_case import load_case_description
-    from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
+    from alfasim_sdk._internal.alfacase.alfacase_to_case import (
+        DescriptionDocument,
+        load_case_description,
+    )
 
     return load_case_description(DescriptionDocument.from_file(file_alfacase))

--- a/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
@@ -1,24 +1,14 @@
 import enum
 import inspect
-from functools import lru_cache
-from functools import partial
+from functools import lru_cache, partial
 from numbers import Number
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Type
-from typing import TypeVar
-from typing import Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import attr
 from attr.validators import instance_of
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
-from barril.units import UnitDatabase
+from barril.units import Array, Scalar, UnitDatabase
 from strictyaml import YAML
 
 from alfasim_sdk._internal import constants

--- a/src/alfasim_sdk/_internal/alfacase/alfatable.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfatable.py
@@ -33,9 +33,9 @@ def load_pvt_model_table_parameters_description_from_alfatable(
     """
     Load the content from the alfatable in the given file_path. The validation is turned off due to performance issues.
     """
-    from strictyaml.ruamel.main import YAML
-    from barril.units import Scalar
     import numpy as np
+    from barril.units import Scalar
+    from strictyaml.ruamel.main import YAML
 
     yaml = YAML(typ="safe", pure=True)
     content = yaml.load(Path(file_path))

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -2,44 +2,36 @@ from contextlib import suppress
 from datetime import datetime
 from numbers import Number
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import Iterator
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
-from typing import Union
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import attr
 import numpy as np
-from attr.validators import in_
-from attr.validators import instance_of
-from attr.validators import optional
+from attr.validators import in_, instance_of, optional
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from ..validators import non_empty_str
-from .case_description_attributes import attrib_array
-from .case_description_attributes import attrib_curve
-from .case_description_attributes import attrib_dict_of
-from .case_description_attributes import attrib_enum
-from .case_description_attributes import attrib_instance
-from .case_description_attributes import attrib_instance_list
-from .case_description_attributes import attrib_scalar
-from .case_description_attributes import collapse_array_repr
-from .case_description_attributes import dict_of
-from .case_description_attributes import dict_of_array
-from .case_description_attributes import dict_with_scalar
-from .case_description_attributes import InvalidReferenceError
-from .case_description_attributes import list_of_optional_integers
-from .case_description_attributes import list_of_strings
-from .case_description_attributes import Numpy1DArray
-from .case_description_attributes import numpy_array_validator
-from .case_description_attributes import PhaseName
 from alfasim_sdk._internal import constants
 
+from ..validators import non_empty_str
+from .case_description_attributes import (
+    InvalidReferenceError,
+    Numpy1DArray,
+    PhaseName,
+    attrib_array,
+    attrib_curve,
+    attrib_dict_of,
+    attrib_enum,
+    attrib_instance,
+    attrib_instance_list,
+    attrib_scalar,
+    collapse_array_repr,
+    dict_of,
+    dict_of_array,
+    dict_with_scalar,
+    list_of_optional_integers,
+    list_of_strings,
+    numpy_array_validator,
+)
 
 # [[[cog
 # # This cog has no output, it just declares and imports symbols used by cogs in this module.
@@ -842,9 +834,9 @@ class CompressorPressureTableDescription:
     @isentropic_efficiency_table.validator
     def _validate_isentropic_efficiency_table(self, attribute, value):
         isen_eff = np.array(value.GetValues("-"))
-        assert np.all(
-            np.logical_and(isen_eff > 0, isen_eff <= 1.0)
-        ), "Isentropic efficiency must be greater than 0 and lower or equal to 1"
+        assert np.all(np.logical_and(isen_eff > 0, isen_eff <= 1.0)), (
+            "Isentropic efficiency must be greater than 0 and lower or equal to 1"
+        )
 
 
 @attr.s(frozen=True, slots=True)
@@ -993,9 +985,9 @@ class PigEquipmentDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True)
@@ -1028,9 +1020,9 @@ class ValveEquipmentDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True)
@@ -1098,9 +1090,9 @@ class LeakEquipmentDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True, kw_only=True)
@@ -1872,15 +1864,15 @@ class SeparatorNodePropertiesDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
     @length.validator
     def _validate_length(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "length"
-        ), "Invalid length"
+        assert isinstance(value, Scalar) and value.GetCategory() == "length", (
+            "Invalid length"
+        )
 
     @gas_separation_efficiency.validator
     def _validate_gas_separation_efficiency(self, attribute, value):
@@ -2074,9 +2066,9 @@ class CasingSectionDescription:
     @outer_diameter.validator
     @inner_diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True, kw_only=True)
@@ -2099,9 +2091,9 @@ class TubingDescription:
     @outer_diameter.validator
     @inner_diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True, kw_only=True)
@@ -2134,9 +2126,9 @@ class OpenHoleDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s(frozen=True, slots=True, kw_only=True)
@@ -2169,9 +2161,9 @@ class GasLiftValveEquipmentDescription:
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
-        assert (
-            isinstance(value, Scalar) and value.GetCategory() == "diameter"
-        ), "Invalid diameter"
+        assert isinstance(value, Scalar) and value.GetCategory() == "diameter", (
+            "Invalid diameter"
+        )
 
 
 @attr.s()
@@ -3373,9 +3365,7 @@ class PvtModelsDescription:
 
             PvtModelsDescription(
                 default_model="PVT1",
-                tables={
-                    'PVT1': Path('./my_tab_file.tab')
-                },
+                tables={"PVT1": Path("./my_tab_file.tab")},
             )
 
     .. tab:: Schema
@@ -3405,7 +3395,7 @@ class PvtModelsDescription:
 
     @staticmethod
     def get_pvt_file_and_model_name(
-        value: Union[str, Path]
+        value: Union[str, Path],
     ) -> Tuple[Path, Optional[str]]:
         """
         Parse the value provided from the user to get the path for the pvt file and if defined, the pvt model.
@@ -3434,11 +3424,11 @@ class TracersDescription:
     .. include:: /alfacase_definitions/TracersDescription.txt
     """
 
-    constant_coefficients: Dict[
-        str, TracerModelConstantCoefficientsDescription
-    ] = attr.ib(
-        default=attr.Factory(dict),
-        validator=dict_of(TracerModelConstantCoefficientsDescription),
+    constant_coefficients: Dict[str, TracerModelConstantCoefficientsDescription] = (
+        attr.ib(
+            default=attr.Factory(dict),
+            validator=dict_of(TracerModelConstantCoefficientsDescription),
+        )
     )
 
 

--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -3,27 +3,13 @@ import textwrap
 from enum import EnumMeta
 from functools import partial
 from numbers import Number
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import NewType
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Union
+from typing import Any, Callable, Dict, List, NewType, Optional, Sequence, Tuple, Union
 
 import attr
 import numpy as np
-from attr.validators import deep_iterable
-from attr.validators import deep_mapping
-from attr.validators import in_
-from attr.validators import instance_of
-from attr.validators import optional
+from attr.validators import deep_iterable, deep_mapping, in_, instance_of, optional
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
-
+from barril.units import Array, Scalar
 
 Numpy1DArray = NewType("Numpy1DArray", np.ndarray)
 PhaseName = str

--- a/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_to_alfacase.py
@@ -1,22 +1,17 @@
 import math
 from enum import Enum
 from functools import partial
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
+from typing import Any, Dict, List, Union
 
 import attr
 import numpy as np
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
 from alfasim_sdk import MultiInputType
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
-from alfasim_sdk._internal.alfacase.generate_schema import IGNORED_PROPERTIES
-from alfasim_sdk._internal.alfacase.generate_schema import is_attrs
+from alfasim_sdk._internal.alfacase.generate_schema import IGNORED_PROPERTIES, is_attrs
 
 ATTRIBUTES = Union[Scalar, Array, Curve, Enum, np.ndarray, List, List[Enum]]
 

--- a/src/alfasim_sdk/_internal/alfacase/generate_case_description_docstring.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_case_description_docstring.py
@@ -1,12 +1,6 @@
 import enum
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Sequence
-from typing import Tuple
-from typing import Type
+from typing import Any, Callable, Dict, List, Sequence, Tuple, Type
 
 import attr
 from attr._make import Attribute
@@ -14,22 +8,23 @@ from barril.curve.curve import Curve
 from barril.units import Array
 from barril.units._scalar import Scalar
 
-from alfasim_sdk._internal.alfacase.generate_schema import IGNORED_PROPERTIES
-from alfasim_sdk._internal.alfacase.generate_schema import is_array
-from alfasim_sdk._internal.alfacase.generate_schema import is_attrs
-from alfasim_sdk._internal.alfacase.generate_schema import is_boolean
-from alfasim_sdk._internal.alfacase.generate_schema import is_curve
-from alfasim_sdk._internal.alfacase.generate_schema import is_dict
-from alfasim_sdk._internal.alfacase.generate_schema import is_enum
-from alfasim_sdk._internal.alfacase.generate_schema import is_float
-from alfasim_sdk._internal.alfacase.generate_schema import is_int
-from alfasim_sdk._internal.alfacase.generate_schema import is_list
-from alfasim_sdk._internal.alfacase.generate_schema import is_path
-from alfasim_sdk._internal.alfacase.generate_schema import is_scalar
-from alfasim_sdk._internal.alfacase.generate_schema import is_str
-from alfasim_sdk._internal.alfacase.generate_schema import is_union
-from alfasim_sdk._internal.alfacase.generate_schema import obtain_schema_name
-
+from alfasim_sdk._internal.alfacase.generate_schema import (
+    IGNORED_PROPERTIES,
+    is_array,
+    is_attrs,
+    is_boolean,
+    is_curve,
+    is_dict,
+    is_enum,
+    is_float,
+    is_int,
+    is_list,
+    is_path,
+    is_scalar,
+    is_str,
+    is_union,
+    obtain_schema_name,
+)
 
 INDENT = "    "
 
@@ -126,7 +121,7 @@ def _generate_declaration_for_class(class_: Any) -> List[str]:
     """Return all attributes for the given Class with CaseDescription definition."""
     class_fields = attr.fields_dict(class_)
     return [
-        f"{INDENT*2}class {class_.__name__}",
+        f"{INDENT * 2}class {class_.__name__}",
         *_get_declaration(class_fields, LIST_OF_CASE_ATTRIBUTES),
     ]
 

--- a/src/alfasim_sdk/_internal/alfacase/generate_schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_schema.py
@@ -6,14 +6,12 @@ from collections import deque
 from contextlib import contextmanager
 from enum import EnumMeta
 from pathlib import Path
-from typing import List
-from typing import Set
+from typing import List, Set
 
 import attr
 import typing_inspect
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 from strictyaml.utils import flatten
 from typing_inspect import is_optional_type
 
@@ -44,7 +42,7 @@ def is_list(type_: type) -> bool:
 
 def list_to_alfacase_schema(type_: type, indent: int) -> str:
     list_value = typing_inspect.get_args(type_)[0]
-    return f"Seq({_get_attr_value(list_value, indent=indent+1)})"
+    return f"Seq({_get_attr_value(list_value, indent=indent + 1)})"
 
 
 def is_float(type_: type) -> bool:
@@ -373,7 +371,7 @@ def _get_classes(class_: type) -> Set[type]:
 
     classes = []
     for key, value in attr.fields_dict(class_).items():
-        if needs_schema(value.type) and not key in IGNORED_PROPERTIES:
+        if needs_schema(value.type) and key not in IGNORED_PROPERTIES:
             classes.append(get_attr_class_type(value.type))
 
     return set(flatten(classes))

--- a/src/alfasim_sdk/_internal/alfacase/plugin_alfacase_to_case.py
+++ b/src/alfasim_sdk/_internal/alfacase/plugin_alfacase_to_case.py
@@ -1,51 +1,45 @@
 import itertools
 from functools import partial
-from pathlib import Path
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from types import ModuleType
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Type
-from typing import Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import attr
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 from typing_extensions import TypeGuard
 
 from alfasim_sdk import BaseField
-from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
-from alfasim_sdk._internal.alfacase.alfacase_to_case import load_value
-from alfasim_sdk._internal.alfacase.alfacase_to_case import to_case_values
-from alfasim_sdk._internal.alfacase.case_description import CaseDescription
-from alfasim_sdk._internal.alfacase.case_description import (
-    InternalReferencePluginTableColumn,
+from alfasim_sdk._internal.alfacase.alfacase_to_case import (
+    DescriptionDocument,
+    load_value,
+    to_case_values,
 )
-from alfasim_sdk._internal.alfacase.case_description import PluginDescription
-from alfasim_sdk._internal.alfacase.case_description import PluginFileContent
-from alfasim_sdk._internal.alfacase.case_description import PluginInternalReference
-from alfasim_sdk._internal.alfacase.case_description import PluginMultipleReference
-from alfasim_sdk._internal.alfacase.case_description import PluginTableContainer
-from alfasim_sdk._internal.alfacase.case_description import PluginTracerReference
 from alfasim_sdk._internal.alfacase.case_description import (
+    CaseDescription,
+    InternalReferencePluginTableColumn,
+    PluginDescription,
+    PluginFileContent,
+    PluginInternalReference,
+    PluginMultipleReference,
+    PluginTableContainer,
+    PluginTracerReference,
     TracerReferencePluginTableColumn,
 )
 from alfasim_sdk._internal.alfacase.case_description_attributes import (
     InvalidPluginDataError,
 )
 from alfasim_sdk._internal.alfacase.plugin_introspection import get_attributes
-from alfasim_sdk._internal.types import Boolean
-from alfasim_sdk._internal.types import Enum
-from alfasim_sdk._internal.types import FileContent
-from alfasim_sdk._internal.types import MultipleReference
-from alfasim_sdk._internal.types import Quantity
-from alfasim_sdk._internal.types import Reference
-from alfasim_sdk._internal.types import String
-from alfasim_sdk._internal.types import Table
-from alfasim_sdk._internal.types import TracerType
+from alfasim_sdk._internal.types import (
+    Boolean,
+    Enum,
+    FileContent,
+    MultipleReference,
+    Quantity,
+    Reference,
+    String,
+    Table,
+    TracerType,
+)
 
 _CHILDREN_LIST_KEY = "_children_list"
 
@@ -271,8 +265,7 @@ def _convert_enum(
     if isinstance(value, str) and (value in type_from_plugin.values):
         return value
     raise InvalidPluginDataError(
-        f"Can not convert to an enum: {value!r}"
-        f" (valid values are {type_from_plugin.values!r}"
+        f"Can not convert to an enum: {value!r} (valid values are {type_from_plugin.values!r}"
     )
 
 

--- a/src/alfasim_sdk/_internal/alfacase/plugin_introspection.py
+++ b/src/alfasim_sdk/_internal/alfacase/plugin_introspection.py
@@ -3,9 +3,7 @@ from typing import List
 import attr
 
 from alfasim_sdk import BaseField
-from alfasim_sdk._internal.types import Group
-from alfasim_sdk._internal.types import Tab
-from alfasim_sdk._internal.types import Tabs
+from alfasim_sdk._internal.types import Group, Tab, Tabs
 
 
 def _is_tab(value: BaseField) -> bool:

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 # fmt: off
 # #[[[cog
 # import cog

--- a/src/alfasim_sdk/_internal/alfasim_sdk_utils.py
+++ b/src/alfasim_sdk/_internal/alfasim_sdk_utils.py
@@ -1,14 +1,8 @@
-from typing import Any
-from typing import Dict
-from typing import Optional
-from typing import Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import attr
 
-from alfasim_sdk._internal.types import BaseField
-from alfasim_sdk._internal.types import Group
-from alfasim_sdk._internal.types import Tab
-from alfasim_sdk._internal.types import Tabs
+from alfasim_sdk._internal.types import BaseField, Group, Tab, Tabs
 
 
 def get_attr_class(

--- a/src/alfasim_sdk/_internal/cli.py
+++ b/src/alfasim_sdk/_internal/cli.py
@@ -6,7 +6,6 @@ from textwrap import dedent
 import click
 from hookman.hookman_generator import HookManGenerator
 
-
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 plugin_dir_option = click.option(

--- a/src/alfasim_sdk/_internal/context.py
+++ b/src/alfasim_sdk/_internal/context.py
@@ -1,20 +1,17 @@
-from typing import List
-from typing import Optional
+from typing import List, Optional
 
 import attr
-from attr.validators import deep_iterable
-from attr.validators import in_
-from attr.validators import instance_of
-from attr.validators import optional
+from attr.validators import deep_iterable, in_, instance_of, optional
 from barril.units import Scalar
 
-from alfasim_sdk._internal.constants import EmulsionDropletSizeModelType
-from alfasim_sdk._internal.constants import EmulsionInversionPointModelType
-from alfasim_sdk._internal.constants import EmulsionRelativeViscosityModelType
-from alfasim_sdk._internal.constants import HydrodynamicModelType
-from alfasim_sdk._internal.constants import SolidsModelType
-from alfasim_sdk._internal.validators import list_of_strings
-from alfasim_sdk._internal.validators import non_empty_str
+from alfasim_sdk._internal.constants import (
+    EmulsionDropletSizeModelType,
+    EmulsionInversionPointModelType,
+    EmulsionRelativeViscosityModelType,
+    HydrodynamicModelType,
+    SolidsModelType,
+)
+from alfasim_sdk._internal.validators import list_of_strings, non_empty_str
 
 
 @attr.s(frozen=True)
@@ -200,6 +197,7 @@ class Context:
                 name = String(value="ALFAsim", caption="Field")
                 scalar = Quantity(value=1, unit="degC", caption="Field")
 
+
             @alfasim_sdk.hookimpl
             def alfasim_get_data_model_type():
                 return [MyModel]
@@ -209,10 +207,10 @@ class Context:
         .. code-block:: console
 
 
-            >>> ctx.get_model('MyModel')
+            >>> ctx.get_model("MyModel")
             MyModel(name='ALFAsim', scalar=Scalar(1.0, 'degC', 'temperature'))
 
-            >>> ctx.get_model('MyModel').name
+            >>> ctx.get_model("MyModel").name
             'ALFAsim'
 
         At runtime, you can also verify the names of the models defined by a given plugin.
@@ -275,6 +273,7 @@ class Context:
             class MyModel:
                 name = String(value="ALFAsim", caption="Field")
                 scalar = Quantity(value=1, unit="degC", caption="Field")
+
 
             @alfasim_sdk.hookimpl
             def alfasim_get_data_model_type():

--- a/src/alfasim_sdk/_internal/hook_specs_gui.py
+++ b/src/alfasim_sdk/_internal/hook_specs_gui.py
@@ -44,9 +44,11 @@ def alfasim_get_data_model_type():
         from alfasim_sdk import data_model
         from alfasim_sdk import Quantity
 
+
         @data_model(icon="", caption="My Plugin")
         class MyModel:
             distance = Quantity(value=1, unit="m", caption="Distance")
+
 
         @alfasim_sdk.hookimpl
         def alfasim_get_data_model_type():
@@ -69,14 +71,15 @@ def alfasim_get_data_model_type():
         from alfasim_sdk import data_model, container_model
         from alfasim_sdk import Quantity, String
 
+
         @data_model(icon="", caption="My Child")
         class ChildModel:
             distance = Quantity(value=1, unit="m", caption="Distance")
 
 
-        @container_model(icon='', caption='My Container', model=ChildModel)
+        @container_model(icon="", caption="My Container", model=ChildModel)
         class MyModelContainer:
-            my_string = String(value='Initial Value', caption='My String')
+            my_string = String(value="Initial Value", caption="My String")
 
 
         @alfasim_sdk.hookimpl
@@ -96,17 +99,20 @@ def alfasim_get_data_model_type():
         from alfasim_sdk import data_model, container_model
         from alfasim_sdk import Quantity, String
 
+
         @data_model(icon="", caption="My Model")
         class MyModel:
             distance = Quantity(value=1, unit="m", caption="Distance")
+
 
         @data_model(icon="", caption="My Child")
         class ChildModel:
             distance = Quantity(value=1, unit="m", caption="Distance")
 
-        @container_model(icon='', caption='My Container', model=ChildModel)
+
+        @container_model(icon="", caption="My Container", model=ChildModel)
         class MyModelContainer:
-            my_string = String(value='Initial Value', caption='My String')
+            my_string = String(value="Initial Value", caption="My String")
 
 
         @alfasim_sdk.hookimpl
@@ -141,18 +147,20 @@ def alfasim_get_additional_variables():
         from alfasim_sdk import Location
         from alfasim_sdk import Scope
 
+
         @alfasim_sdk.hookimpl
         def alfasim_get_additional_variables():
             return [
                 SecondaryVariable(
-                    name='dummy_variable',
-                    caption='Plugin 1',
-                    unit='m',
+                    name="dummy_variable",
+                    caption="Plugin 1",
+                    unit="m",
                     visibility=Visibility.Internal,
                     location=Location.Center,
                     multifield_scope=Scope.Global,
                     checked_on_gui_default=True,
-                )]
+                )
+            ]
     """
 
 
@@ -194,12 +202,11 @@ def alfasim_get_status(
         from alfasim_sdk import Quantity
         from alfasim_sdk import ErrorMessage
 
+
         # Define MyModel used in this plugin
         @data_model(icon="", caption="My Plugin Model")
         class MyModel:
-            distance = Quantity(
-                value=1, unit="m", caption="Distance"
-            )
+            distance = Quantity(value=1, unit="m", caption="Distance")
 
 
         @alfasim_sdk.hookimpl
@@ -252,10 +259,10 @@ def alfasim_configure_fields(ctx: Context):
 
         @alfasim_sdk.hookimpl
         def alfasim_configure_fields(ctx):
-           return [
-               AddField(name='plugin_continuous_field'),
-               AddField(name='plugin_dispersed_field'),
-           ]
+            return [
+                AddField(name="plugin_continuous_field"),
+                AddField(name="plugin_dispersed_field"),
+            ]
 
 
     """
@@ -280,17 +287,17 @@ def alfasim_configure_layers(ctx: Context):
 
         @alfasim_sdk.hookimpl
         def alfasim_configure_layers(ctx):
-           return [
-               AddLayer(
-                   name='plugin_layer',
-                   fields=['plugin_continuous_field'],
-                   continuous_field='plugin_continuous_field',
-               ),
-               UpdateLayer(
-                   name=OIL_LAYER,
-                   additional_fields=['plugin_dispersed_field'],
-               ),
-           ]
+            return [
+                AddLayer(
+                    name="plugin_layer",
+                    fields=["plugin_continuous_field"],
+                    continuous_field="plugin_continuous_field",
+                ),
+                UpdateLayer(
+                    name=OIL_LAYER,
+                    additional_fields=["plugin_dispersed_field"],
+                ),
+            ]
 
     The image below shows the new added phase on the application.
 
@@ -320,12 +327,12 @@ def alfasim_configure_phases(ctx: Context):
         def alfasim_configure_phases(ctx):
             return [
                 AddPhase(
-                    name='plugin_phase',
+                    name="plugin_phase",
                     fields=[
-                        'plugin_continuous_field',
-                        'plugin_dispersed_field',
+                        "plugin_continuous_field",
+                        "plugin_dispersed_field",
                     ],
-                    primary_field='plugin_continuous_field',
+                    primary_field="plugin_continuous_field",
                     is_solid=False,
                 )
             ]
@@ -358,7 +365,7 @@ def alfasim_configure_phases(ctx: Context):
             return [
                 UpdatePhase(
                     name=OIL_PHASE,
-                    additional_fields=['plugin_dispersed_field'],
+                    additional_fields=["plugin_dispersed_field"],
                 )
             ]
 
@@ -386,9 +393,10 @@ def alfasim_get_phase_properties_calculated_from_plugin():
 
         from alfasim_sdk import GAS_PHASE
 
+
         @alfasim_sdk.hookimpl
         def alfasim_get_phase_properties_calculated_from_plugin():
-            return [GAS_PHASE, 'solid']
+            return [GAS_PHASE, "solid"]
 
     """
 
@@ -439,7 +447,7 @@ def alfasim_get_user_defined_tracers_from_plugin():
 
         @alfasim_sdk.hookimpl
         def alfasim_get_user_defined_tracers_from_plugin():
-            return ['my_tracer']
+            return ["my_tracer"]
 
     .. note::
         The tracer added in the `user-defined tracers from plugin` list will not be considered as a standard tracer, which

--- a/src/alfasim_sdk/_internal/layout.py
+++ b/src/alfasim_sdk/_internal/layout.py
@@ -4,9 +4,7 @@ from typing import Callable
 import attr
 
 from alfasim_sdk._internal.alfasim_sdk_utils import get_attr_class
-from alfasim_sdk._internal.types import Group
-from alfasim_sdk._internal.types import Tab
-from alfasim_sdk._internal.types import Tabs
+from alfasim_sdk._internal.types import Group, Tab, Tabs
 
 
 def tabs() -> Callable:
@@ -27,7 +25,6 @@ def tabs() -> Callable:
 
             @tabs()
             class MainPage:
-
                 @tab(caption="Fist Tab")
                 class Tab1:
                     field_1 = String(caption="First Tab", value="Default")

--- a/src/alfasim_sdk/_internal/models.py
+++ b/src/alfasim_sdk/_internal/models.py
@@ -1,6 +1,5 @@
 import functools
-from typing import Callable
-from typing import Optional
+from typing import Callable, Optional
 
 from alfasim_sdk._internal.alfasim_sdk_utils import get_attr_class
 
@@ -47,9 +46,9 @@ def container_model(
             distance = Quantity(value=1, unit="m", caption="Distance")
 
 
-        @container_model(icon='', caption='My Container', model=ChildModel)
+        @container_model(icon="", caption="My Container", model=ChildModel)
         class MyModelContainer:
-            my_string = String(value='Initial Value', caption='My String')
+            my_string = String(value="Initial Value", caption="My String")
 
 
         @alfasim_sdk.hookimpl
@@ -142,14 +141,14 @@ def data_model(*, caption: str, icon: Optional[str] = None) -> Callable:
 
     .. code-block:: python
 
-        @data_model(icon='', caption='My Plugin')
+        @data_model(icon="", caption="My Plugin")
         class MyModel:
-                distance = Quantity(value=1, unit='m', caption='Distance')
+            distance = Quantity(value=1, unit="m", caption="Distance")
 
 
         @alfasim_sdk.hookimpl
         def alfasim_get_data_model_type():
-                return [MyModel]
+            return [MyModel]
 
     .. image:: /_static/images/api/data_model_example_1_1.png
         :scale: 90%

--- a/src/alfasim_sdk/_internal/types.py
+++ b/src/alfasim_sdk/_internal/types.py
@@ -1,19 +1,12 @@
 import numbers
-from typing import Callable
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Union
+from typing import Callable, List, Optional, Sequence, Union
 
 import attr
 from attr import attrib
 from attr._make import Attribute
-from attr.validators import instance_of
-from attr.validators import is_callable
-from attr.validators import optional
+from attr.validators import instance_of, is_callable, optional
 
-from alfasim_sdk._internal.validators import non_empty_str
-from alfasim_sdk._internal.validators import valid_unit
+from alfasim_sdk._internal.validators import non_empty_str, valid_unit
 
 
 @attr.s(kw_only=True, frozen=True)
@@ -74,18 +67,19 @@ class BaseField:
 
     .. code-block:: python
 
-        @data_model(icon='', caption='My Plugin')
+        @data_model(icon="", caption="My Plugin")
         class MyModel:
-            my_string_1= String(
-                value='String 1',
-                caption='My String 1',
+            my_string_1 = String(
+                value="String 1",
+                caption="My String 1",
                 tooltip="Some Text <br> <b> More Information</b>",
             )
             my_string_2 = String(
-                value='String 2',
-                caption='My String 2',
+                value="String 2",
+                caption="My String 2",
                 tooltip="∩ ∪ ∫ ∬ ∮",
             )
+
 
         @alfasim_sdk.hookimpl
         def alfasim_get_data_model_type():
@@ -126,15 +120,17 @@ class BaseField:
         def my_check(self, ctx):
             return self.bool_value
 
+
         @data_model(icon="", caption="My Plugin")
         class MyModel:
             bool_value = Boolean(value=True, caption="Enabled")
             N_ions = Quantity(
-                caption='Number of Ions',
+                caption="Number of Ions",
                 value=1,
-                unit='-',
+                unit="-",
                 enable_expr=my_check,
             )
+
 
         @alfasim_sdk.hookimpl
         def alfasim_get_data_model_type():
@@ -496,9 +492,7 @@ class MultipleReference(BaseReference):
 
         @data_model(icon="", caption="My Plugin")
         class MyModel:
-            tracer_ref = MultipleReference(
-                ref_type=TracerType, caption="Tracer Type"
-            )
+            tracer_ref = MultipleReference(ref_type=TracerType, caption="Tracer Type")
 
 
     .. image:: /_static/images/api/multiplereference_field_example_1.png
@@ -590,9 +584,7 @@ class Quantity(BaseField):
 
         @data_model(icon="", caption="My Plugin")
         class MyModel:
-            quantity_field = Quantity(
-                value=1, unit="degC", caption="Quantity Field"
-            )
+            quantity_field = Quantity(value=1, unit="degC", caption="Quantity Field")
 
 
     .. image:: /_static/images/api/quantity_field_example.png
@@ -684,13 +676,15 @@ class Table(BaseField):
         class FlowType:
             name = String(value="Flow", caption="Name")
 
+
         @container_model(caption="Flow Types", model=FlowType, icon="")
         class FlowTypeContainer:
             pass
 
+
         @data_model(icon="", caption="My Model")
         class MyModel:
-            table_field=Table(
+            table_field = Table(
                 rows=[
                     TableColumn(
                         id="temperature",

--- a/src/alfasim_sdk/_internal/validators.py
+++ b/src/alfasim_sdk/_internal/validators.py
@@ -1,8 +1,7 @@
 from typing import Any
 
 from attr._make import Attribute
-from attr.validators import deep_iterable
-from attr.validators import instance_of
+from attr.validators import deep_iterable, instance_of
 
 
 def non_empty_str(self: Any, attribute: Attribute, value: str) -> None:

--- a/src/alfasim_sdk/_internal/variables.py
+++ b/src/alfasim_sdk/_internal/variables.py
@@ -4,12 +4,10 @@ from typing import Optional
 
 import attr
 from attr import attrib
-from attr.validators import instance_of
-from attr.validators import optional
+from attr.validators import instance_of, optional
 from barril.units import UnitDatabase
 
-from alfasim_sdk._internal.validators import non_empty_str
-from alfasim_sdk._internal.validators import valid_unit
+from alfasim_sdk._internal.validators import non_empty_str, valid_unit
 
 
 class Visibility(Enum):

--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -3,17 +3,12 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
-from typing import Union
+from typing import Any, Union
 from zipfile import ZipFile
 
-from colorama import Fore
-from colorama import Style
+from colorama import Fore, Style
 from hookman.hookman_generator import HookManGenerator
-from invoke import Collection
-from invoke import Exit
-from invoke import Task
-from invoke import task
+from invoke import Collection, Exit, Task, task
 from strictyaml.ruamel import YAML
 
 sdk_ns = Collection()
@@ -186,9 +181,9 @@ def compile(ctx, cmake_extra_args="", debug=False, clean=False):
         ],
     )
 
-    assert (
-        shared_lib_path.exists()
-    ), "Compilation task failed, shared lib was not created"
+    assert shared_lib_path.exists(), (
+        "Compilation task failed, shared lib was not created"
+    )
 
     if package_dir.exists():
         shutil.rmtree(package_dir)
@@ -228,11 +223,11 @@ def package_only(ctx, package_name="", dst=""):
 
     hook_specs_file_path = _get_hook_specs_file_path()
     hm = HookManGenerator(hook_spec_file_path=hook_specs_file_path)
-    from alfasim_sdk._internal.constants import EXTRAS_REQUIRED_VERSION_KEY
     from alfasim_sdk._internal.alfasim_sdk_utils import (
         get_current_version,
         get_extras_default_required_version,
     )
+    from alfasim_sdk._internal.constants import EXTRAS_REQUIRED_VERSION_KEY
 
     plugin_id = str(plugin_dir.name)
     if not package_name:

--- a/src/alfasim_sdk/result_reader/__init__.py
+++ b/src/alfasim_sdk/result_reader/__init__.py
@@ -1,5 +1,4 @@
 from .aggregator import ALFASimResultMetadata
 from .reader import Results
 
-
 __all__ = ["ALFASimResultMetadata", "Results"]

--- a/src/alfasim_sdk/result_reader/aggregator.py
+++ b/src/alfasim_sdk/result_reader/aggregator.py
@@ -8,63 +8,46 @@ import re
 from collections import namedtuple
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import DefaultDict
-from typing import Dict
-from typing import Iterator
-from typing import List
-from typing import Literal
-from typing import NamedTuple
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Type
-from typing import TypeVar
-from typing import Union
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import attr
 import h5py
 import numpy
 import numpy as np
-from typing_extensions import Self
-from typing_extensions import TypedDict
+from typing_extensions import Self, TypedDict
 
 from alfasim_sdk.result_reader.aggregator_constants import (
     GLOBAL_SENSITIVITY_ANALYSIS_GROUP_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     HISTORY_MATCHING_DETERMINISTIC_DSET_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import HISTORY_MATCHING_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    HISTORY_MATCHING_GROUP_NAME,
     HISTORY_MATCHING_HISTORIC_DATA_GROUP_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     HISTORY_MATCHING_PROBABILISTIC_DSET_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import META_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import PROFILES_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    META_GROUP_NAME,
+    PROFILES_GROUP_NAME,
     PROFILES_STATISTICS_DSET_NAME_SUFFIX,
-)
-from alfasim_sdk.result_reader.aggregator_constants import RESULT_FILE_LOCKING_MODE
-from alfasim_sdk.result_reader.aggregator_constants import RESULT_FILE_PREFIX
-from alfasim_sdk.result_reader.aggregator_constants import TIME_SET_DSET_NAME
-from alfasim_sdk.result_reader.aggregator_constants import TRENDS_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    RESULT_FILE_LOCKING_MODE,
+    RESULT_FILE_PREFIX,
+    TIME_SET_DSET_NAME,
+    TRENDS_GROUP_NAME,
     UNCERTAINTY_PROPAGATION_DSET_MEAN_RESULT,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_DSET_REALIZATION_OUTPUTS,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_DSET_STD_RESULT,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_GROUP_META_ATTR_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_GROUP_NAME,
 )
 
@@ -466,7 +449,7 @@ class HistoryMatchingMetadata:
             }
 
         def map_historic_data_infos(
-            infos: List[Dict[str, Any]]
+            infos: List[Dict[str, Any]],
         ) -> List[HistoricDataCurveMetadata]:
             return [HistoricDataCurveMetadata.from_dict(info) for info in infos]
 
@@ -1179,9 +1162,7 @@ def _merge_metadata_and_read_global_statistics(
             start_index, stop_index = partial_indices[-1]  # The most recent.
 
             if start_index < stop_index:
-                statistics = trends_statistics[
-                    output_id
-                ]  # type: Dict[str, numpy.ndarray]
+                statistics = trends_statistics[output_id]  # type: Dict[str, numpy.ndarray]
                 data_index = meta["index"]
                 min_value, max_value = trends_statistic[:, data_index]
                 statistics["min"] = numpy.nanmin((min_value, statistics["min"]))
@@ -1670,21 +1651,21 @@ def _read_time_sets(
         _TREND_ID_ATTR: [initial_trends_time_step_index, final_trends_time_step_index],
     }
     if initial_profiles_time_step_index is None:
-        time_step_index_range_to_read[_PROFILE_ID_ATTR][
-            0
-        ] = result_metadata.time_steps_boundaries[0][0]
+        time_step_index_range_to_read[_PROFILE_ID_ATTR][0] = (
+            result_metadata.time_steps_boundaries[0][0]
+        )
     if final_profiles_time_step_index is None:
-        time_step_index_range_to_read[_PROFILE_ID_ATTR][
-            1
-        ] = result_metadata.time_steps_boundaries[1][0]
+        time_step_index_range_to_read[_PROFILE_ID_ATTR][1] = (
+            result_metadata.time_steps_boundaries[1][0]
+        )
     if initial_trends_time_step_index is None:
-        time_step_index_range_to_read[_TREND_ID_ATTR][
-            0
-        ] = result_metadata.time_steps_boundaries[0][1]
+        time_step_index_range_to_read[_TREND_ID_ATTR][0] = (
+            result_metadata.time_steps_boundaries[0][1]
+        )
     if final_trends_time_step_index is None:
-        time_step_index_range_to_read[_TREND_ID_ATTR][
-            1
-        ] = result_metadata.time_steps_boundaries[1][1]
+        time_step_index_range_to_read[_TREND_ID_ATTR][1] = (
+            result_metadata.time_steps_boundaries[1][1]
+        )
 
     cache = {}
     for time_set_key in time_sets_key_list:
@@ -1756,7 +1737,7 @@ def _read_time_set(
 
 
 def _concatenate_values(
-    data_dict: Dict[Any, List[numpy.ndarray]]
+    data_dict: Dict[Any, List[numpy.ndarray]],
 ) -> Dict[Any, numpy.ndarray]:
     """
     Concatenate the values in the given dict.
@@ -1772,7 +1753,7 @@ def _concatenate_values(
 
 
 def map_output_key_to_time_set_key(
-    all_metadata: Dict[int, Dict]
+    all_metadata: Dict[int, Dict],
 ) -> Dict[OutputKeyType, TimeSetKeyType]:
     """
     Operates on the complete metadata mapping "output key"s to they  respective "time set key".
@@ -1791,7 +1772,7 @@ def map_output_key_to_time_set_key(
 
 
 def map_base_time_set_to_time_set_keys(
-    output_key_to_time_set_key_dict: Dict[OutputKeyType, TimeSetKeyType]
+    output_key_to_time_set_key_dict: Dict[OutputKeyType, TimeSetKeyType],
 ) -> Dict[int, Tuple[TimeSetKeyType, ...]]:
     """
     Maps base time steps to the "time set key"s where they are found.

--- a/src/alfasim_sdk/result_reader/reader.py
+++ b/src/alfasim_sdk/result_reader/reader.py
@@ -1,54 +1,42 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import Sequence
-from typing import Tuple
-from typing import Union
+from typing import Any, Callable, Dict, Sequence, Tuple, Union
 
 import attr
 import numpy as np
 from attr import define
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 from typing_extensions import Self
 
-from alfasim_sdk.result_reader.aggregator import ALFASimResultMetadata
-from alfasim_sdk.result_reader.aggregator import GlobalSensitivityAnalysisMetadata
-from alfasim_sdk.result_reader.aggregator import GSAOutputKey
-from alfasim_sdk.result_reader.aggregator import HistoricDataCurveMetadata
-from alfasim_sdk.result_reader.aggregator import HistoryMatchingMetadata
-from alfasim_sdk.result_reader.aggregator import HMOutputKey
 from alfasim_sdk.result_reader.aggregator import (
+    ALFASimResultMetadata,
+    GlobalSensitivityAnalysisMetadata,
+    GSAOutputKey,
+    HistoricDataCurveMetadata,
+    HistoryMatchingMetadata,
+    HMOutputKey,
+    UncertaintyPropagationAnalysesMetaData,
+    UPOutputKey,
+    UPResult,
     read_global_sensitivity_analysis_meta_data,
-)
-from alfasim_sdk.result_reader.aggregator import read_global_sensitivity_coefficients
-from alfasim_sdk.result_reader.aggregator import (
+    read_global_sensitivity_coefficients,
     read_history_matching_historic_data_curves,
-)
-from alfasim_sdk.result_reader.aggregator import read_history_matching_metadata
-from alfasim_sdk.result_reader.aggregator import read_history_matching_result
-from alfasim_sdk.result_reader.aggregator import read_metadata
-from alfasim_sdk.result_reader.aggregator import read_profiles_data
-from alfasim_sdk.result_reader.aggregator import read_profiles_domain_data
-from alfasim_sdk.result_reader.aggregator import read_time_sets
-from alfasim_sdk.result_reader.aggregator import read_trends_data
-from alfasim_sdk.result_reader.aggregator import (
+    read_history_matching_metadata,
+    read_history_matching_result,
+    read_metadata,
+    read_profiles_data,
+    read_profiles_domain_data,
+    read_time_sets,
+    read_trends_data,
     read_uncertainty_propagation_analyses_meta_data,
+    read_uncertainty_propagation_results,
+    read_uq_time_set,
 )
-from alfasim_sdk.result_reader.aggregator import read_uncertainty_propagation_results
-from alfasim_sdk.result_reader.aggregator import read_uq_time_set
-from alfasim_sdk.result_reader.aggregator import UncertaintyPropagationAnalysesMetaData
-from alfasim_sdk.result_reader.aggregator import UPOutputKey
-from alfasim_sdk.result_reader.aggregator import UPResult
 from alfasim_sdk.result_reader.aggregator_constants import (
     GLOBAL_SENSITIVITY_ANALYSIS_GROUP_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import RESULTS_FOLDER_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    RESULTS_FOLDER_NAME,
     UNCERTAINTY_PROPAGATION_GROUP_NAME,
 )
 

--- a/src/alfasim_sdk/testing/fixtures.py
+++ b/src/alfasim_sdk/testing/fixtures.py
@@ -5,18 +5,14 @@ import textwrap
 import uuid
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Iterator
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Iterator, List, Optional, Union
 
 import pytest
 import strictyaml
 from _pytest.compat import assert_never
 from _pytest.monkeypatch import MonkeyPatch
 
-from alfasim_sdk import convert_alfacase_to_description
-from alfasim_sdk import generate_alfacase_file
+from alfasim_sdk import convert_alfacase_to_description, generate_alfacase_file
 from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
 from alfasim_sdk._internal.alfacase.case_description import CaseDescription
 from alfasim_sdk._internal.alfacase.case_description_attributes import DescriptionError
@@ -125,8 +121,7 @@ class AlfasimRunnerFixture:
         alfacase_content = DescriptionDocument(content, self.alfacase_file)
         plugin_description = load_plugin(alfacase_content)
         assert plugin_description is not None, (
-            "Can not load the plugin info,"
-            " maybe you forgot to call `add_plugin_folder`"
+            "Can not load the plugin info, maybe you forgot to call `add_plugin_folder`"
         )
         self._case.plugins.append(plugin_description)
 
@@ -172,7 +167,7 @@ class AlfasimRunnerFixture:
 
                 name = log_file.name
                 header_len = 4 + len(name) + 4
-                return f'{"=" * header_len}\n=== {log_file.name} ===\n{"=" * header_len}\n{contents}'
+                return f"{'=' * header_len}\n=== {log_file.name} ===\n{'=' * header_len}\n{contents}"
 
             results = Results(self.alfacase_data_folder)
             log_calc = results.log_calc
@@ -192,8 +187,7 @@ class AlfasimRunnerFixture:
         """
         runner_from_env = os.environ.get("ALFASIM_RUNNER")
         assert runner_from_env is not None, (
-            "Can not locate the simulator."
-            " Set the environment variable 'ALFASIM_RUNNER'."
+            "Can not locate the simulator. Set the environment variable 'ALFASIM_RUNNER'."
         )
         return runner_from_env.split(" ")
 

--- a/tasks.py
+++ b/tasks.py
@@ -41,12 +41,12 @@ def cog(ctx, check=False):
     ctx.run(command=f"cog -rc {case_description_source_file_path()}", warn=True)
     ctx.run(command=f"cog -rc {schema_file_path()}", warn=True)
 
-    from alfasim_sdk._internal.alfacase.generate_schema import (
-        get_all_classes_that_needs_schema,
-    )
     from alfasim_sdk._internal.alfacase.case_description import CaseDescription
     from alfasim_sdk._internal.alfacase.generate_case_description_docstring import (
         generate_definition,
+    )
+    from alfasim_sdk._internal.alfacase.generate_schema import (
+        get_all_classes_that_needs_schema,
     )
 
     alfacase_definitions_path().mkdir(parents=True, exist_ok=True)
@@ -61,8 +61,8 @@ def cog(ctx, check=False):
         write_alfacase_definitions_cogged_file(f"{class_.__name__}.txt", output)
 
     from alfasim_sdk._internal.alfacase.generate_case_description_docstring import (
-        generate_list_of_units,
         CATEGORIES_USED_ON_DESCRIPTION,
+        generate_list_of_units,
     )
 
     for category in CATEGORIES_USED_ON_DESCRIPTION:

--- a/tasks.py
+++ b/tasks.py
@@ -38,8 +38,8 @@ def cog(ctx, check=False):
     - on `_internal/alfacase/schema.py` to generate the schema for strictyaml;
     - generate some documentation files;
     """
-    ctx.run(command=f"cog -rc {case_description_source_file_path()}", warn=True)
-    ctx.run(command=f"cog -rc {schema_file_path()}", warn=True)
+    ctx.run(command=f"cog -rc {case_description_source_file_path()}")
+    ctx.run(command=f"cog -rc {schema_file_path()}")
 
     from alfasim_sdk._internal.alfacase.case_description import CaseDescription
     from alfasim_sdk._internal.alfacase.generate_case_description_docstring import (

--- a/tests/alfacase/test_alfacase_to_case.py
+++ b/tests/alfacase/test_alfacase_to_case.py
@@ -6,39 +6,39 @@ import attr
 import numpy
 import pytest
 import strictyaml
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 from strictyaml import YAML
 from strictyaml.ruamel.comments import CommentedMap
 
-from ..common_testing.alfasim_sdk_common_testing import filled_case_descriptions
-from ..common_testing.alfasim_sdk_common_testing import get_acme_tab_file_path
-from ..common_testing.alfasim_sdk_common_testing.filled_case_descriptions import (
-    ensure_descriptions_are_equal,
-)
 from alfasim_sdk import convert_description_to_alfacase
-from alfasim_sdk._internal.alfacase import alfacase_to_case
-from alfasim_sdk._internal.alfacase import case_description
-from alfasim_sdk._internal.alfacase import schema
-from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
-from alfasim_sdk._internal.alfacase.alfacase_to_case import get_array_loader
-from alfasim_sdk._internal.alfacase.alfacase_to_case import get_scalar_loader
+from alfasim_sdk._internal.alfacase import alfacase_to_case, case_description, schema
 from alfasim_sdk._internal.alfacase.alfacase_to_case import (
+    DescriptionDocument,
+    get_array_loader,
+    get_scalar_loader,
     load_mass_source_node_properties_description,
+    load_physics_description,
+    load_pvt_models_description,
 )
-from alfasim_sdk._internal.alfacase.alfacase_to_case import load_physics_description
-from alfasim_sdk._internal.alfacase.alfacase_to_case import load_pvt_models_description
 from alfasim_sdk._internal.alfacase.case_description_attributes import DescriptionError
-from alfasim_sdk._internal.alfacase.generate_schema import convert_to_snake_case
 from alfasim_sdk._internal.alfacase.generate_schema import (
+    IGNORED_PROPERTIES,
+    convert_to_snake_case,
     get_all_classes_that_needs_schema,
+    is_attrs,
 )
-from alfasim_sdk._internal.alfacase.generate_schema import IGNORED_PROPERTIES
-from alfasim_sdk._internal.alfacase.generate_schema import is_attrs
 from alfasim_sdk._internal.alfacase.schema import (
     mass_source_node_properties_description_schema,
 )
 from alfasim_sdk._internal.constants import MultiInputType
+
+from ..common_testing.alfasim_sdk_common_testing import (
+    filled_case_descriptions,
+    get_acme_tab_file_path,
+)
+from ..common_testing.alfasim_sdk_common_testing.filled_case_descriptions import (
+    ensure_descriptions_are_equal,
+)
 
 
 @attr.s(frozen=True)
@@ -132,9 +132,9 @@ def alfacase_to_case_helper(tmp_path):
                 key for key in obtained_keys if key not in IGNORED_PROPERTIES
             }
 
-            assert (
-                expected_keys == obtained_keys
-            ), f"Error: missing the following key(s): {set(expected_keys).symmetric_difference(set(obtained_keys))}"
+            assert expected_keys == obtained_keys, (
+                f"Error: missing the following key(s): {set(expected_keys).symmetric_difference(set(obtained_keys))}"
+            )
 
     return AlfacaseHelper(tmp_path)
 

--- a/tests/alfacase/test_alfatable.py
+++ b/tests/alfacase/test_alfatable.py
@@ -2,10 +2,12 @@ from textwrap import dedent
 
 import numpy as np
 
-from alfasim_sdk import convert_alfacase_to_description
-from alfasim_sdk import generate_alfacase_file
-from alfasim_sdk import generate_alfatable_file
-from alfasim_sdk import PvtModelPtTableParametersDescription
+from alfasim_sdk import (
+    PvtModelPtTableParametersDescription,
+    convert_alfacase_to_description,
+    generate_alfacase_file,
+    generate_alfatable_file,
+)
 
 
 def test_alfatable_has_flow_style_for_numpy_array(tmp_path):

--- a/tests/alfacase/test_case_description.py
+++ b/tests/alfacase/test_case_description.py
@@ -1,50 +1,36 @@
 import re
 import textwrap
 from textwrap import dedent
-from typing import Any
-from typing import Callable
+from typing import Any, Callable
 
 import attr
 import pytest
 from attr._make import _CountingAttr
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
+
+from alfasim_sdk import MaterialDescription, NodeCellType
+from alfasim_sdk._internal import constants
+from alfasim_sdk._internal.alfacase import case_description
+from alfasim_sdk._internal.alfacase.case_description_attributes import (
+    InvalidReferenceError,
+    attrib_array,
+    attrib_curve,
+    attrib_enum,
+    attrib_instance,
+    attrib_instance_list,
+    attrib_scalar,
+    collapse_array_repr,
+    generate_multi_input,
+    generate_multi_input_dict,
+    numpy_array_validator,
+    to_array,
+    to_curve,
+)
 
 from ..common_testing.alfasim_sdk_common_testing.case_builders import (
     build_simple_segment,
 )
-from alfasim_sdk import MaterialDescription
-from alfasim_sdk import NodeCellType
-from alfasim_sdk._internal import constants
-from alfasim_sdk._internal.alfacase import case_description
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_array
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_curve
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_enum
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    attrib_instance,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    attrib_instance_list,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_scalar
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    collapse_array_repr,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    generate_multi_input,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    generate_multi_input_dict,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    InvalidReferenceError,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import (
-    numpy_array_validator,
-)
-from alfasim_sdk._internal.alfacase.case_description_attributes import to_array
-from alfasim_sdk._internal.alfacase.case_description_attributes import to_curve
 
 
 # Note: the table parameters descriptions have the same methods, so it could
@@ -64,8 +50,8 @@ def test_physics_description_path_validator(tmp_path):
     """
     Ensure PhysicsDescription.restart_filepath only accepts created files
     """
-    from pathlib import Path
     import re
+    from pathlib import Path
 
     expected_error = re.escape(
         f"'restart_filepath' must be {Path} (got '' that is a {str})."
@@ -405,7 +391,8 @@ class TestResetInvalidReferences:
         case = attr.evolve(
             default_case,
             pvt_models=case_description.PvtModelsDescription(
-                default_model="PVT1", tables={"PVT1": f"{tmp_path/'dummy.tab'}|INVALID"}
+                default_model="PVT1",
+                tables={"PVT1": f"{tmp_path / 'dummy.tab'}|INVALID"},
             ),
         )
         case.reset_invalid_references()
@@ -413,7 +400,7 @@ class TestResetInvalidReferences:
         assert case.pvt_models.default_model is None
         case = case_description.CaseDescription(
             pvt_models=case_description.PvtModelsDescription(
-                default_model="PVT2", tables={"PVT2": f"{tmp_path/'dummy.tab'}|PVT2"}
+                default_model="PVT2", tables={"PVT2": f"{tmp_path / 'dummy.tab'}|PVT2"}
             )
         )
         case.reset_invalid_references()
@@ -570,7 +557,8 @@ class TestEnsureValidReferences:
         case = attr.evolve(
             default_case,
             pvt_models=case_description.PvtModelsDescription(
-                default_model="PVT1", tables={"PVT1": f"{tmp_path/'dummy.tab'}|INVALID"}
+                default_model="PVT1",
+                tables={"PVT1": f"{tmp_path / 'dummy.tab'}|INVALID"},
             ),
         )
         expect_message = "'INVALID' could not be found on 'dummy.tab', available models are: 'PVT1, PVT2'"
@@ -583,7 +571,7 @@ class TestEnsureValidReferences:
         # Ensure the test finishes in a valid state
         case = case_description.CaseDescription(
             pvt_models=case_description.PvtModelsDescription(
-                default_model="PVT2", tables={"PVT2": f"{tmp_path/'dummy.tab'}|PVT2"}
+                default_model="PVT2", tables={"PVT2": f"{tmp_path / 'dummy.tab'}|PVT2"}
             )
         )
         case.ensure_valid_references()

--- a/tests/alfacase/test_case_to_alfacase.py
+++ b/tests/alfacase/test_case_to_alfacase.py
@@ -2,17 +2,19 @@ import re
 from pathlib import Path
 
 import pytest
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
+
+from alfasim_sdk import (
+    MultiInputType,
+    NumericalOptionsDescription,
+    convert_description_to_alfacase,
+)
+from alfasim_sdk._internal.alfacase import case_description
+from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
 
 from ..common_testing.alfasim_sdk_common_testing.case_builders import (
     build_simple_segment,
 )
-from alfasim_sdk import convert_description_to_alfacase
-from alfasim_sdk import MultiInputType
-from alfasim_sdk import NumericalOptionsDescription
-from alfasim_sdk._internal.alfacase import case_description
-from alfasim_sdk._internal.alfacase.alfacase_to_case import DescriptionDocument
 
 
 def test_convert_description_to_alfacase_with_empty_dict(datadir: Path) -> None:

--- a/tests/alfacase/test_generate_case_schema.py
+++ b/tests/alfacase/test_generate_case_schema.py
@@ -1,27 +1,22 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Dict, List, Optional, Union
 
 import attr
 import pytest
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from alfasim_sdk import CaseDescription
-from alfasim_sdk import CompressorEquipmentDescription
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_enum
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_instance
+from alfasim_sdk import CaseDescription, CompressorEquipmentDescription
 from alfasim_sdk._internal.alfacase.case_description_attributes import (
+    Numpy1DArray,
+    attrib_enum,
+    attrib_instance,
     attrib_instance_list,
+    attrib_scalar,
 )
-from alfasim_sdk._internal.alfacase.case_description_attributes import attrib_scalar
-from alfasim_sdk._internal.alfacase.case_description_attributes import Numpy1DArray
-from alfasim_sdk._internal.alfacase.generate_schema import _obtain_referred_type
-from alfasim_sdk._internal.alfacase.generate_schema import generate_alfacase_schema
 from alfasim_sdk._internal.alfacase.generate_schema import (
+    _obtain_referred_type,
+    generate_alfacase_schema,
     get_all_classes_that_needs_schema,
 )
 from alfasim_sdk._internal.alfacase.schema import case_description_schema
@@ -495,9 +490,7 @@ def test_get_cases_class():
         "WellDescription",
         "XAndYDescription",
     }
-    assert (
-        obtained == expected
-    ), f"""
+    assert obtained == expected, f"""
            Missing in the expected: {obtained.difference(expected) or None}.
            Extra in expected: {expected.difference(obtained) or None}
        """

--- a/tests/alfacase/test_generate_list_of_units.py
+++ b/tests/alfacase/test_generate_list_of_units.py
@@ -2,8 +2,6 @@ import pytest
 
 from alfasim_sdk._internal.alfacase.generate_case_description_docstring import (
     CATEGORIES_USED_ON_DESCRIPTION,
-)
-from alfasim_sdk._internal.alfacase.generate_case_description_docstring import (
     generate_list_of_units,
 )
 

--- a/tests/alfacase/test_plugin_alfacase_to_case.py
+++ b/tests/alfacase/test_plugin_alfacase_to_case.py
@@ -2,29 +2,23 @@ import os
 import textwrap
 from datetime import datetime
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import List
+from typing import Any, Callable, List
 from unittest.mock import ANY
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 from pytest_mock import MockerFixture
 
-from alfasim_sdk import convert_alfacase_to_description
-from alfasim_sdk import PluginDescription
-from alfasim_sdk._internal.alfacase.case_description import CaseDescription
+from alfasim_sdk import PluginDescription, convert_alfacase_to_description
 from alfasim_sdk._internal.alfacase.case_description import (
+    CaseDescription,
     InternalReferencePluginTableColumn,
-)
-from alfasim_sdk._internal.alfacase.case_description import PluginFileContent
-from alfasim_sdk._internal.alfacase.case_description import PluginInternalReference
-from alfasim_sdk._internal.alfacase.case_description import PluginMultipleReference
-from alfasim_sdk._internal.alfacase.case_description import PluginTableContainer
-from alfasim_sdk._internal.alfacase.case_description import PluginTracerReference
-from alfasim_sdk._internal.alfacase.case_description import (
+    PluginFileContent,
+    PluginInternalReference,
+    PluginMultipleReference,
+    PluginTableContainer,
+    PluginTracerReference,
     TracerReferencePluginTableColumn,
 )
 from alfasim_sdk._internal.alfacase.case_description_attributes import (
@@ -32,11 +26,7 @@ from alfasim_sdk._internal.alfacase.case_description_attributes import (
 )
 from alfasim_sdk._internal.alfacase.plugin_alfacase_to_case import (
     dump_file_contents_and_update_plugins,
-)
-from alfasim_sdk._internal.alfacase.plugin_alfacase_to_case import (
     get_plugin_module_candidates,
-)
-from alfasim_sdk._internal.alfacase.plugin_alfacase_to_case import (
     load_plugin_data_structure,
 )
 

--- a/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
@@ -1,5 +1,4 @@
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
@@ -125,12 +124,12 @@ def build_compressor_pressure_table_description(
     making it a explicit table with all combinations.
     """
     expected_size = len(speed_entries) * len(corrected_mass_flow_rate_entries)
-    assert expected_size == len(
-        pressure_ratio_table
-    ), f"Missing pressure entries. Expected {expected_size} but got {len(pressure_ratio_table)}"
-    assert expected_size == len(
-        isentropic_efficiency_table
-    ), f"Missing isentropic efficiency entries. Expected {expected_size} but got {len(isentropic_efficiency_table)}"
+    assert expected_size == len(pressure_ratio_table), (
+        f"Missing pressure entries. Expected {expected_size} but got {len(pressure_ratio_table)}"
+    )
+    assert expected_size == len(isentropic_efficiency_table), (
+        f"Missing isentropic efficiency entries. Expected {expected_size} but got {len(isentropic_efficiency_table)}"
+    )
 
     adjusted_speeds = []
     adjusted_flow_rates = []

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -2,15 +2,14 @@ from pathlib import Path
 
 import numpy as np
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from . import case_builders
-from . import get_acme_tab_file_path
 from alfasim_sdk import LeakLocation
 from alfasim_sdk._internal import constants
 from alfasim_sdk._internal.alfacase import case_description
 from alfasim_sdk._internal.alfacase.alfacase_to_case import get_category_for
+
+from . import case_builders, get_acme_tab_file_path
 
 BIP_DESCRIPTION = case_description.BipDescription(
     component_1="C1", component_2="C2", value=0.5
@@ -988,9 +987,9 @@ def ensure_descriptions_are_equal(
         if is_ndarray or (
             is_list and isinstance(first(expected_value, None), np.ndarray)
         ):
-            assert np.array_equal(
-                obtained_description_dict[key], expected_value
-            ), f"Not equal on {path}{key}"
+            assert np.array_equal(obtained_description_dict[key], expected_value), (
+                f"Not equal on {path}{key}"
+            )
             continue  # pragma no cover [bug on coverage.py: https://github.com/nedbat/coveragepy/issues/198]
 
         is_array = isinstance(expected_value, Array)
@@ -998,9 +997,9 @@ def ensure_descriptions_are_equal(
             unit = expected_value.GetUnit()
             obtained_values = np.array(obtained_description_dict[key].GetValues(unit))
             expected_values = np.array(expected_value.GetValues(unit))
-            assert np.allclose(
-                obtained_values, expected_values
-            ), f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            assert np.allclose(obtained_values, expected_values), (
+                f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            )
             continue  # pragma no cover [bug on coverage.py
 
         is_curve = isinstance(expected_value, Curve)
@@ -1009,21 +1008,21 @@ def ensure_descriptions_are_equal(
             domain_unit = expected_value.GetDomain().GetUnit()
             expected_domain_values = expected_value.GetDomain().GetValues(domain_unit)
             obtained_domain_values = obtained_curve.GetDomain().GetValues(domain_unit)
-            assert np.allclose(
-                expected_domain_values, obtained_domain_values
-            ), f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            assert np.allclose(expected_domain_values, obtained_domain_values), (
+                f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            )
             image_unit = expected_value.GetImage().GetUnit()
             expected_image_values = expected_value.GetImage().GetValues(image_unit)
             obtained_image_values = obtained_curve.GetImage().GetValues(image_unit)
-            assert np.allclose(
-                expected_image_values, obtained_image_values
-            ), f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            assert np.allclose(expected_image_values, obtained_image_values), (
+                f"Not equal on {path}{key}\nObtained={obtained_values} != {expected_values}"
+            )
             continue  # pragma no cover [bug on coverage.py: https://github.com/nedbat/coveragepy/issues/198]
 
         # Skip the check when materials or walls only has defaults values
         if key in ("materials", "walls") and first(expected_value, None) is None:
             continue
 
-        assert (
-            obtained_description_dict[key] == expected_value
-        ), f'Not equal on {path}{key}\nAttribute "{key}" doesn\'t match, obtained "{obtained_description_dict[key]}" while "{expected_value}" was expected.'
+        assert obtained_description_dict[key] == expected_value, (
+            f'Not equal on {path}{key}\nAttribute "{key}" doesn\'t match, obtained "{obtained_description_dict[key]}" while "{expected_value}" was expected.'
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,7 @@ import os.path
 import shutil
 import textwrap
 from pathlib import Path
-from typing import Dict
-from typing import List
+from typing import Dict, List
 
 import h5py
 import numpy as np
@@ -17,33 +16,18 @@ from alfasim_sdk.result_reader.aggregator import (
 )
 from alfasim_sdk.result_reader.aggregator_constants import (
     GLOBAL_SENSITIVITY_ANALYSIS_GROUP_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     HISTORY_MATCHING_DETERMINISTIC_DSET_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import HISTORY_MATCHING_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    HISTORY_MATCHING_GROUP_NAME,
     HISTORY_MATCHING_PROBABILISTIC_DSET_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import META_GROUP_NAME
-from alfasim_sdk.result_reader.aggregator_constants import TIME_SET_DSET_NAME
-from alfasim_sdk.result_reader.aggregator_constants import (
+    META_GROUP_NAME,
+    TIME_SET_DSET_NAME,
     UNCERTAINTY_PROPAGATION_DSET_MEAN_RESULT,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_DSET_REALIZATION_OUTPUTS,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_DSET_STD_RESULT,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_GROUP_META_ATTR_NAME,
-)
-from alfasim_sdk.result_reader.aggregator_constants import (
     UNCERTAINTY_PROPAGATION_GROUP_NAME,
 )
 from alfasim_sdk.result_reader.reader import Results
-
 
 pytest_plugins = [
     "alfasim_sdk.testing.fixtures",

--- a/tests/plugins/test_context.py
+++ b/tests/plugins/test_context.py
@@ -3,18 +3,22 @@ import re
 import pytest
 from barril.units import Scalar
 
-from alfasim_sdk._internal.constants import EmulsionDropletSizeModelType
-from alfasim_sdk._internal.constants import EmulsionInversionPointModelType
-from alfasim_sdk._internal.constants import EmulsionRelativeViscosityModelType
-from alfasim_sdk._internal.constants import HydrodynamicModelType
-from alfasim_sdk._internal.constants import SolidsModelType
-from alfasim_sdk._internal.context import EdgeInfo
-from alfasim_sdk._internal.context import EmulsionModelInfo
-from alfasim_sdk._internal.context import HydrodynamicModelInfo
-from alfasim_sdk._internal.context import NodeInfo
-from alfasim_sdk._internal.context import PhysicsOptionsInfo
-from alfasim_sdk._internal.context import PipelineInfo
-from alfasim_sdk._internal.context import PipelineSegmentInfo
+from alfasim_sdk._internal.constants import (
+    EmulsionDropletSizeModelType,
+    EmulsionInversionPointModelType,
+    EmulsionRelativeViscosityModelType,
+    HydrodynamicModelType,
+    SolidsModelType,
+)
+from alfasim_sdk._internal.context import (
+    EdgeInfo,
+    EmulsionModelInfo,
+    HydrodynamicModelInfo,
+    NodeInfo,
+    PhysicsOptionsInfo,
+    PipelineInfo,
+    PipelineSegmentInfo,
+)
 
 
 def test_plugin_info():

--- a/tests/plugins/test_layout.py
+++ b/tests/plugins/test_layout.py
@@ -1,13 +1,12 @@
 import pytest
 
-from alfasim_sdk._internal.layout import tab
-from alfasim_sdk._internal.layout import tabs
+from alfasim_sdk._internal.layout import tab, tabs
 from alfasim_sdk._internal.types import String
 
 
 def test_group():
-    from alfasim_sdk._internal.models import data_model
     from alfasim_sdk._internal.layout import group
+    from alfasim_sdk._internal.models import data_model
 
     @data_model(caption="Foo")
     class ValidClass:
@@ -65,9 +64,9 @@ def test_group():
 
 
 def test_tabs():
-    from alfasim_sdk._internal.types import String
-    from alfasim_sdk._internal.layout import tabs, tab
+    from alfasim_sdk._internal.layout import tab, tabs
     from alfasim_sdk._internal.models import data_model
+    from alfasim_sdk._internal.types import String
 
     error_msg = "Error on attribute 'a' expecting a class decorated with @tab but received a String type"
     with pytest.raises(TypeError, match=error_msg):

--- a/tests/plugins/test_models.py
+++ b/tests/plugins/test_models.py
@@ -91,11 +91,11 @@ def test_attribute_order():
     from alfasim_sdk._internal.models import data_model
     from alfasim_sdk._internal.types import (
         Boolean,
-        Reference,
-        TracerType,
         Enum,
-        String,
         Quantity,
+        Reference,
+        String,
+        TracerType,
     )
 
     @data_model(icon="", caption="caption")

--- a/tests/plugins/test_status.py
+++ b/tests/plugins/test_status.py
@@ -2,8 +2,7 @@ import re
 
 import pytest
 
-from alfasim_sdk import ErrorMessage
-from alfasim_sdk import WarningMessage
+from alfasim_sdk import ErrorMessage, WarningMessage
 
 
 @pytest.mark.parametrize("status_class", [WarningMessage, ErrorMessage])

--- a/tests/plugins/test_types.py
+++ b/tests/plugins/test_types.py
@@ -2,8 +2,7 @@ import re
 
 import pytest
 
-from alfasim_sdk._internal.types import MultipleReference
-from alfasim_sdk._internal.types import Reference
+from alfasim_sdk._internal.types import MultipleReference, Reference
 
 
 @pytest.mark.parametrize("expression_type", ["enable_expr", "visible_expr"])
@@ -81,8 +80,8 @@ def test_enum():
 
 @pytest.mark.parametrize("class_", [Reference, MultipleReference])
 def test_reference(class_):
+    from alfasim_sdk._internal.models import container_model, data_model
     from alfasim_sdk._internal.types import TracerType
-    from alfasim_sdk._internal.models import data_model, container_model
 
     @data_model(caption="caption")
     class Data:
@@ -160,7 +159,7 @@ def test_table():
 
 
 def test_table_column():
-    from alfasim_sdk._internal.types import TableColumn, Quantity
+    from alfasim_sdk._internal.types import Quantity, TableColumn
 
     with pytest.raises(
         TypeError, match="value must be a Quantity or a Reference, got a <class 'str'>."

--- a/tests/plugins/test_variables.py
+++ b/tests/plugins/test_variables.py
@@ -24,11 +24,11 @@ import pytest
 )
 def test_validation(attr, expected_type_error, expected_message):
     from alfasim_sdk._internal.variables import (
-        Visibility,
         Location,
         Scope,
         SecondaryVariable,
         Type,
+        Visibility,
     )
 
     attrs = dict(

--- a/tests/results/test_aggregator.py
+++ b/tests/results/test_aggregator.py
@@ -3,8 +3,7 @@ import itertools
 import re
 import shutil
 from pathlib import Path
-from typing import List
-from typing import Literal
+from typing import List, Literal
 
 import numpy
 import pytest
@@ -12,39 +11,33 @@ from pytest import FixtureRequest
 from pytest_mock import MockerFixture
 from pytest_regressions.num_regression import NumericRegressionFixture
 
-from alfasim_sdk.result_reader.aggregator import concatenate_metadata
-from alfasim_sdk.result_reader.aggregator import GSAOutputKey
-from alfasim_sdk.result_reader.aggregator import HistoricDataCurveMetadata
-from alfasim_sdk.result_reader.aggregator import HistoryMatchingMetadata
-from alfasim_sdk.result_reader.aggregator import HMOutputKey
-from alfasim_sdk.result_reader.aggregator import open_result_files
 from alfasim_sdk.result_reader.aggregator import (
+    GSAOutputKey,
+    HistoricDataCurveMetadata,
+    HistoryMatchingMetadata,
+    HMOutputKey,
+    ResultsNeedFullReloadError,
+    TimeSetInfoItem,
+    UPOutputKey,
+    concatenate_metadata,
+    open_result_files,
     read_global_sensitivity_analysis_meta_data,
-)
-from alfasim_sdk.result_reader.aggregator import read_global_sensitivity_coefficients
-from alfasim_sdk.result_reader.aggregator import (
+    read_global_sensitivity_coefficients,
     read_history_matching_historic_data_curves,
-)
-from alfasim_sdk.result_reader.aggregator import read_history_matching_metadata
-from alfasim_sdk.result_reader.aggregator import read_history_matching_result
-from alfasim_sdk.result_reader.aggregator import read_metadata
-from alfasim_sdk.result_reader.aggregator import read_profiles_local_statistics
-from alfasim_sdk.result_reader.aggregator import read_time_sets
-from alfasim_sdk.result_reader.aggregator import read_trends_data
-from alfasim_sdk.result_reader.aggregator import (
+    read_history_matching_metadata,
+    read_history_matching_result,
+    read_metadata,
+    read_profiles_local_statistics,
+    read_time_sets,
+    read_trends_data,
     read_uncertainty_propagation_analyses_meta_data,
-)
-from alfasim_sdk.result_reader.aggregator import read_uncertainty_propagation_results
-from alfasim_sdk.result_reader.aggregator import (
+    read_uncertainty_propagation_results,
     read_uq_time_set,
 )
-from alfasim_sdk.result_reader.aggregator import ResultsNeedFullReloadError
-from alfasim_sdk.result_reader.aggregator import TimeSetInfoItem
-from alfasim_sdk.result_reader.aggregator import UPOutputKey
 from alfasim_sdk.result_reader.aggregator_constants import (
     GLOBAL_SENSITIVITY_ANALYSIS_GROUP_NAME,
+    RESULTS_FOLDER_NAME,
 )
-from alfasim_sdk.result_reader.aggregator_constants import RESULTS_FOLDER_NAME
 from alfasim_sdk.result_reader.reader import Results
 
 

--- a/tests/results/test_result_reader.py
+++ b/tests/results/test_result_reader.py
@@ -8,27 +8,30 @@ import numpy
 import numpy as np
 import pytest
 from barril.curve.curve import Curve
-from barril.units import Array
-from barril.units import Scalar
+from barril.units import Array, Scalar
 
-from alfasim_sdk.result_reader.aggregator import GlobalSensitivityAnalysisMetadata
-from alfasim_sdk.result_reader.aggregator import GSAOutputKey
-from alfasim_sdk.result_reader.aggregator import HistoricDataCurveMetadata
-from alfasim_sdk.result_reader.aggregator import HistoryMatchingMetadata
-from alfasim_sdk.result_reader.aggregator import HMOutputKey
-from alfasim_sdk.result_reader.aggregator import read_history_matching_metadata
-from alfasim_sdk.result_reader.aggregator import read_history_matching_result
-from alfasim_sdk.result_reader.aggregator import UncertaintyPropagationAnalysesMetaData
-from alfasim_sdk.result_reader.aggregator import UPOutputKey
-from alfasim_sdk.result_reader.reader import GlobalSensitivityAnalysisResults
-from alfasim_sdk.result_reader.reader import GlobalTrendMetadata
-from alfasim_sdk.result_reader.reader import HistoryMatchingDeterministicResults
-from alfasim_sdk.result_reader.reader import HistoryMatchingProbabilisticResults
-from alfasim_sdk.result_reader.reader import OverallTrendMetadata
-from alfasim_sdk.result_reader.reader import PositionalTrendMetadata
-from alfasim_sdk.result_reader.reader import ProfileMetadata
-from alfasim_sdk.result_reader.reader import Results
-from alfasim_sdk.result_reader.reader import UncertaintyPropagationResults
+from alfasim_sdk.result_reader.aggregator import (
+    GlobalSensitivityAnalysisMetadata,
+    GSAOutputKey,
+    HistoricDataCurveMetadata,
+    HistoryMatchingMetadata,
+    HMOutputKey,
+    UncertaintyPropagationAnalysesMetaData,
+    UPOutputKey,
+    read_history_matching_metadata,
+    read_history_matching_result,
+)
+from alfasim_sdk.result_reader.reader import (
+    GlobalSensitivityAnalysisResults,
+    GlobalTrendMetadata,
+    HistoryMatchingDeterministicResults,
+    HistoryMatchingProbabilisticResults,
+    OverallTrendMetadata,
+    PositionalTrendMetadata,
+    ProfileMetadata,
+    Results,
+    UncertaintyPropagationResults,
+)
 
 
 def test_fail_to_get_curves(results: Results) -> None:

--- a/tests/test_alfasim_sdk_utils.py
+++ b/tests/test_alfasim_sdk_utils.py
@@ -26,8 +26,7 @@ def test_get_metadata() -> None:
     from alfasim_sdk._internal.alfasim_sdk_utils import get_metadata
 
     @data_model(icon="model.png", caption="PLUGIN DEV MODEL")
-    class Model:
-        ...
+    class Model: ...
 
     assert get_metadata(Model)["caption"] == "PLUGIN DEV MODEL"
     assert get_metadata(Model)["icon"] == "model.png"

--- a/tests/test_case_builders.py
+++ b/tests/test_case_builders.py
@@ -1,25 +1,16 @@
 import pytest
 from barril.units import Array
 
+from alfasim_sdk._internal import constants
+
 from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_compressor_pressure_table_description,
-)
-from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_constant_initial_pressure_description,
-)
-from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_constant_initial_temperatures_description,
-)
-from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_constant_pvt_table,
-)
-from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_linear_initial_pressure_description,
-)
-from .common_testing.alfasim_sdk_common_testing.case_builders import (
     build_linear_initial_temperatures_description,
 )
-from alfasim_sdk._internal import constants
 
 
 def test_build_constant_initial_temperatures_description():

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -11,7 +11,6 @@ from _pytest.monkeypatch import MonkeyPatch
 
 from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
 
-
 plugin_id = "acme"
 invoke_cmd = shutil.which("invoke")
 alfasim_sdk_cmd = shutil.which("alfasim-sdk")


### PR DESCRIPTION
As https://github.com/ESSS/alfasim-sdk/pull/360 shows, black and reorder-python-imports conflict on how they format imports.

Switch over to `ruff` + its builtin import sorter (isort).