### PR TITLE
Remove check of same result dir on concatenate_metadata function

### DIFF
--- a/src/alfasim_sdk/result_reader/aggregator.py
+++ b/src/alfasim_sdk/result_reader/aggregator.py
@@ -1800,9 +1800,6 @@ def concatenate_metadata(
     Concatenate two result metadata objects.
     """
 
-    if r_b.result_directory != r_a.result_directory:
-        raise RuntimeError("Can not concatenate result from different sources.")
-
     a_initial_ts_index, a_final_ts_index = r_a.time_steps_boundaries
     if a_initial_ts_index == a_final_ts_index:
         return r_b


### PR DESCRIPTION
This constraint is not true anymore once we can have multiple results directories in the client/server architecture.

Related: https://github.com/ESSS/alfasim/pull/882.

ASIM-5916