### PR TITLE
Remove results dir from metadata objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 1.1.0 (Unreleased)
 ==================
 
+* **Breaking Change**: Remove the ``result_directory`` attribute from all the result metadata objects declared in ``result_reader.aggregator`` module and instead demand it to be passed as argument to the result reading functions (``read_time_sets``, ``read_history_matching_result`` and so on); do so to ensure metadata is independent from the result file location, as demanded by the new ALFAsim client/server architecture.
+
+
 1.0.0 (2025-02-07)
 ==================
 

--- a/src/alfasim_sdk/result_reader/reader.py
+++ b/src/alfasim_sdk/result_reader/reader.py
@@ -129,10 +129,10 @@ class Results:
         metadata = self.metadata
         trend_metadata = metadata.trends[trend_key]
         time_set_key = ("trend_id", trend_metadata["time_set_key"])
-        time_sets = read_time_sets(metadata, [time_set_key])
+        time_sets = read_time_sets(self.results_folder, metadata, [time_set_key])
         time_set = time_sets[time_set_key]
 
-        trend_data = read_trends_data(metadata, [trend_key])
+        trend_data = read_trends_data(self.results_folder, metadata, [trend_key])
         data = trend_data[trend_key]
 
         return Curve(
@@ -150,10 +150,12 @@ class Results:
         """
         metadata = self.metadata
         profile_metadata = metadata.profiles[profile_key]
-        domains = read_profiles_domain_data(metadata, [profile_key], index)
+        domains = read_profiles_domain_data(
+            self.results_folder, metadata, [profile_key], index
+        )
         domain = domains[profile_key]
 
-        images = read_profiles_data(metadata, [profile_key], index)
+        images = read_profiles_data(self.results_folder, metadata, [profile_key], index)
         image = images[profile_key]
 
         return Curve(
@@ -363,7 +365,7 @@ class GlobalSensitivityAnalysisResults:
             timeset=read_uq_time_set(
                 result_dir, GLOBAL_SENSITIVITY_ANALYSIS_GROUP_NAME
             ),
-            coefficients=read_global_sensitivity_coefficients(metadata),
+            coefficients=read_global_sensitivity_coefficients(result_dir, metadata),
             metadata=metadata,
         )
 
@@ -420,9 +422,9 @@ class HistoryMatchingDeterministicResults(_BaseHistoryMatchingResults):
 
         return cls(
             deterministic_values=read_history_matching_result(
-                metadata, "HM-deterministic"
+                result_dir, metadata, "HM-deterministic"
             ),
-            historic_data_curves=_read_curves_data(metadata),
+            historic_data_curves=_read_curves_data(result_dir, metadata),
             metadata=metadata,
         )
 
@@ -441,9 +443,9 @@ class HistoryMatchingProbabilisticResults(_BaseHistoryMatchingResults):
 
         return cls(
             probabilistic_distributions=read_history_matching_result(
-                metadata, "HM-probabilistic"
+                result_dir, metadata, "HM-probabilistic"
             ),
-            historic_data_curves=_read_curves_data(metadata),
+            historic_data_curves=_read_curves_data(result_dir, metadata),
             metadata=metadata,
         )
 
@@ -461,9 +463,10 @@ class HistoryMatchingProbabilisticResults(_BaseHistoryMatchingResults):
 
 
 def _read_curves_data(
+    result_directory: Path,
     metadata: HistoryMatchingMetadata,
 ) -> dict[str, tuple[HistoricDataCurveMetadata, Curve]]:
-    raw_curves = read_history_matching_historic_data_curves(metadata)
+    raw_curves = read_history_matching_historic_data_curves(result_directory, metadata)
     curves_info = metadata.historic_data_curve_infos or []
     curves_info_map = {info.curve_id: info for info in curves_info}
 
@@ -494,7 +497,7 @@ class UncertaintyPropagationResults:
 
         return cls(
             timeset=read_uq_time_set(result_dir, UNCERTAINTY_PROPAGATION_GROUP_NAME),
-            results=read_uncertainty_propagation_results(metadata),
+            results=read_uncertainty_propagation_results(result_dir, metadata),
             metadata=metadata,
         )
 

--- a/tests/results/test_aggregator.py
+++ b/tests/results/test_aggregator.py
@@ -279,23 +279,30 @@ def test_read_profiles_local_statistics(
     results: Results, num_regression: NumericRegressionFixture
 ) -> None:
     local_statistics = read_profiles_local_statistics(
-        results.metadata, list(results.metadata.profiles.keys()), 0
+        results.results_folder,
+        results.metadata,
+        list(results.metadata.profiles.keys()),
+        0,
     )
     num_regression.check(local_statistics)
 
 
 def test_read_trends_data_bounds_check(results: Results) -> None:
     with pytest.raises(ValueError, match="Invalid initial_trends_time_step_index"):
-        read_trends_data(results.metadata, initial_trends_time_step_index=999)
+        read_trends_data(
+            results.results_folder, results.metadata, initial_trends_time_step_index=999
+        )
 
     with pytest.raises(ValueError, match="Invalid final_trends_time_step_index"):
-        read_trends_data(results.metadata, final_trends_time_step_index=999)
+        read_trends_data(
+            results.results_folder, results.metadata, final_trends_time_step_index=999
+        )
 
 
 def test_read_trends_data_empty_arrays_when_no_time_set_info(results: Results) -> None:
     fake_metadata = dataclasses.replace(results.metadata)
     fake_metadata.time_set_info = {}
-    trends = read_trends_data(fake_metadata)
+    trends = read_trends_data(results.results_folder, fake_metadata)
     base_id = "project.study_container.item00001.output_options.trend_out_definition_container"
     assert set(trends.keys()) == {
         f"pipe total liquid volume@{base_id}.item00003",
@@ -327,7 +334,7 @@ def test_fancy_path(datadir: Path, request: FixtureRequest):
 def test_read_time_sets(
     results: Results, num_regression: NumericRegressionFixture
 ) -> None:
-    time_sets = read_time_sets(results.metadata)
+    time_sets = read_time_sets(results.results_folder, results.metadata)
     num_regression.check({str(k): v for k, v in time_sets.items()})
 
 
@@ -371,6 +378,7 @@ def test_read_gsa_timeset(global_sa_results_dir: Path) -> None:
 def test_read_uq_global_sensitivity_analysis(global_sa_results_dir: Path) -> None:
     metadata = read_global_sensitivity_analysis_meta_data(global_sa_results_dir)
     data = read_global_sensitivity_coefficients(
+        result_directory=global_sa_results_dir,
         coefficients_key=[
             GSAOutputKey("temperature", "parametric_var_1", "trend_id_1"),
             GSAOutputKey("temperature", "parametric_var_2", "trend_id_1"),
@@ -424,7 +432,6 @@ def test_read_history_matching_result_metadata(
     # Existent and completed result file, metadata should be filled.
     metadata = read_history_matching_metadata(hm_results_dir)
 
-    assert metadata.result_directory == hm_results_dir
     assert metadata.objective_functions == {
         "observed_curve_1": {"trend_id": "trend_1", "property_id": "holdup"},
         "observed_curve_2": {"trend_id": "trend_2", "property_id": "pressure"},
@@ -508,7 +515,10 @@ def test_read_history_matching_result_data(
 
     # Read the result of a single parametric var entry.
     result = read_history_matching_result(
-        metadata, hm_type=hm_type, hm_result_key=HMOutputKey("parametric_var_1")
+        results_dir,
+        metadata,
+        hm_type=hm_type,
+        hm_result_key=HMOutputKey("parametric_var_1"),
     )
     assert len(result) == 1
     assert result[HMOutputKey("parametric_var_1")] == pytest.approx(
@@ -516,7 +526,7 @@ def test_read_history_matching_result_data(
     )
 
     # Read the result of all entries.
-    result = read_history_matching_result(metadata, hm_type=hm_type)
+    result = read_history_matching_result(results_dir, metadata, hm_type=hm_type)
     assert len(result) == 2
     assert result[HMOutputKey("parametric_var_1")] == pytest.approx(
         expected_results[HMOutputKey("parametric_var_1")]
@@ -527,7 +537,7 @@ def test_read_history_matching_result_data(
 
     # Nonexistent result key, result should be empty.
     result = read_history_matching_result(
-        metadata, hm_type=hm_type, hm_result_key=HMOutputKey("foo")
+        results_dir, metadata, hm_type=hm_type, hm_result_key=HMOutputKey("foo")
     )
     assert result == {}
 
@@ -535,14 +545,14 @@ def test_read_history_matching_result_data(
     creating_file = results_dir / "result.creating"
     creating_file.touch()
 
-    result = read_history_matching_result(metadata, hm_type=hm_type)
+    result = read_history_matching_result(results_dir, metadata, hm_type=hm_type)
     assert result == {}
 
     creating_file.unlink()
 
     # Receiving an invalid History Matching type should raise.
     with pytest.raises(ValueError, match="type `foobar` not supported"):
-        read_history_matching_result(metadata, "foobar")  # type: ignore
+        read_history_matching_result(results_dir, metadata, "foobar")  # type: ignore
 
 
 def test_read_history_matching_historic_data_curves(
@@ -555,7 +565,7 @@ def test_read_history_matching_historic_data_curves(
     result_directories = (hm_probabilistic_results_dir, hm_deterministic_results_dir)
     for result_dir in result_directories:
         metadata = read_history_matching_metadata(result_dir)
-        curves = read_history_matching_historic_data_curves(metadata)
+        curves = read_history_matching_historic_data_curves(result_dir, metadata)
         assert len(curves) == 2
         assert curves["observed_curve_1"] == pytest.approx(
             numpy.array([[0.1, 0.5, 0.9], [1.1, 2.2, 3.3]])
@@ -569,9 +579,8 @@ def test_read_history_matching_historic_data_curves(
         hm_items={},
         objective_functions={},
         parametric_vars={},
-        result_directory=Path("foo"),
     )
-    assert read_history_matching_historic_data_curves(meta) == {}
+    assert read_history_matching_historic_data_curves(Path("foo"), meta) == {}
 
 
 def test_read_history_matching_historic_data_curves_backward_compatibility(
@@ -583,7 +592,7 @@ def test_read_history_matching_historic_data_curves_backward_compatibility(
     """
     result_dir = hm_results_dir_without_historic_data
     metadata = read_history_matching_metadata(result_dir)
-    curves = read_history_matching_historic_data_curves(metadata)
+    curves = read_history_matching_historic_data_curves(result_dir, metadata)
     assert curves == {}
 
 
@@ -621,7 +630,7 @@ def test_read_uncertainty_propagation_results(
     ]
 
     result = read_uncertainty_propagation_results(
-        metadata=metadata, result_keys=[temp_key]
+        result_directory=up_results_dir, metadata=metadata, result_keys=[temp_key]
     )
     assert len(result) == 1
     dict_1 = {
@@ -633,7 +642,7 @@ def test_read_uncertainty_propagation_results(
     num_regression.check(dict_1, basename=str(temp_key))
 
     result = read_uncertainty_propagation_results(
-        metadata=metadata, result_keys=[pressure_key]
+        result_directory=up_results_dir, metadata=metadata, result_keys=[pressure_key]
     )
     assert len(result) == 1
     dict_2 = {

--- a/tests/results/test_result_reader.py
+++ b/tests/results/test_result_reader.py
@@ -251,7 +251,9 @@ class TestHistoryMatchingResultsReader:
         reader to read probabilistic results and vice-versa.
         """
         prob_metadata = read_history_matching_metadata(hm_probabilistic_results_dir)
-        prob_values = read_history_matching_result(prob_metadata, "HM-probabilistic")
+        prob_values = read_history_matching_result(
+            hm_probabilistic_results_dir, prob_metadata, "HM-probabilistic"
+        )
 
         with pytest.raises(
             ValueError,
@@ -264,7 +266,9 @@ class TestHistoryMatchingResultsReader:
             )
 
         det_metadata = read_history_matching_metadata(hm_deterministic_results_dir)
-        det_values = read_history_matching_result(det_metadata, "HM-deterministic")
+        det_values = read_history_matching_result(
+            hm_deterministic_results_dir, det_metadata, "HM-deterministic"
+        )
 
         with pytest.raises(
             ValueError,


### PR DESCRIPTION
With the introduction of the ALFAsim client-server a result can be stored in multiples places (and eventually in multiple data stores), so the presence of this info along with the real result metadata doesn't make sense anymore.

ASIM-6121