### PR TITLE
Update barril constrain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,8 @@ CHANGELOG
 * Add backward compatibility for alfacase files which does not specify the version in plugins.
 * Add ``version`` property for ``PluginsDescription``
 * **Breaking Change**: Add ``alfasim_get_version`` GUI specification hook to be implemented by plugins.
-* **Breaking Change**: ``HydrodynamicModelType.ThreeLayersNoBubbleGasOilWater``  renamed to ``HydrodynamicModelType.TwoLayersGasOilWater``
+* **Breaking Change**: ``HydrodynamicModelType.ThreeLayersNoBubbleGasOilWater``  renamed to ``HydrodynamicModelType.TwoLayersGasOilWater``.
+* Update barril constrain to allow barril from the major version 2.
 
 1.1.0 (2025-05-28)
 ==================

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,6 @@ install_requires =
     strictyaml>=1.4.3
     boltons
     Click>=7.0
-    barril>=1.13,<2.0
+    barril>=1.13,<3.0
     pluggy>=0.13.0
     h5py


### PR DESCRIPTION
Barril did enter the 3.X series without API changes.

The error in "[docs/readthedocs.org:alfasim-sdk](https://app.readthedocs.org/projects/alfasim-sdk/builds/29643285/) — Read the Docs build failed!" is the same from master.