### PR TITLE
[ASIM-6351] Add pressure in curve_names for POSITIONAL_PIPE_TREND_OUTPUT_DESCRIPTION

### DIFF
--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -436,7 +436,7 @@ SURGE_VOLUME_OPTIONS_DESCRIPTION = case_description.SurgeVolumeOptionsDescriptio
 )
 POSITIONAL_PIPE_TREND_OUTPUT_DESCRIPTION = (
     case_description.PositionalPipeTrendDescription(
-        curve_names=["oil mass flow rate","pressure"],
+        curve_names=["oil mass flow rate", "pressure"],
         element_name="pipe 1",
         position=Scalar(2950.0, "m"),
         location=constants.OutputAttachmentLocation.Main,


### PR DESCRIPTION
To select a property in a ContollerInputSignal, it is necessary that the associated trend has this property availabe on it curve_names.

ASIM-6351