### PR TITLE
[ASIM-6524] Add damp_slug_flow to numerical options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 ==================
 
 * Allow users to configure parametric runs in alfacase file.
+* Added ``damp_slug_flow`` attribute to ``NumericalOptionsDescription``. It controls whether the flow pattern transition involving slug flow should be dampened in a transient simulation. If it's ``True``, the flow pattern of the previous timestep will be copied to the current timestep in case the difference between the gas and liquid superficial velocities is close to that of the previous timestep.
 
 1.5.1 (2026-01-08)
 ==================

--- a/docs/source/alfacase_definitions/NumericalOptionsDescription.txt
+++ b/docs/source/alfacase_definitions/NumericalOptionsDescription.txt
@@ -18,6 +18,7 @@
             caching_rtol: float | \ :class:`FloatExpression <alfasim_sdk._internal.alfacase.case_description_attributes.FloatExpression>`\  = 0.01
             caching_atol: float | \ :class:`FloatExpression <alfasim_sdk._internal.alfacase.case_description_attributes.FloatExpression>`\  = 0.0001
             always_repeat_timestep: bool = False
+            damp_slug_flow: bool = False
             enable_fast_compositional: bool = True
 
 .. tab:: Schema
@@ -46,4 +47,5 @@
             caching_atol:  # optional
                 number | expr
             always_repeat_timestep: boolean  # optional
+            damp_slug_flow: boolean  # optional
             enable_fast_compositional: boolean  # optional

--- a/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
@@ -2017,6 +2017,7 @@ def load_numerical_options_description(
         "caching_rtol": load_float,
         "caching_atol": load_float,
         "always_repeat_timestep": load_value,
+        "damp_slug_flow": load_value,
         "enable_fast_compositional": load_value,
     }
     case_values = to_case_values(document, alfacase_to_case_description)

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -3930,6 +3930,12 @@ class TimeOptionsDescription:
 @attr.s(auto_attribs=True)
 class NumericalOptionsDescription:
     """
+    :ivar damp_slug_flow:
+        Control whether the flow pattern transition involving slug flow should be dampened in a
+        transient simulation. If it's ``True``, the flow pattern of the previous timestep will be
+        copied to the current timestep in case the difference between the gas and liquid superficial
+        velocities is close to that of the previous timestep.
+
     .. include:: /alfacase_definitions/NumericalOptionsDescription.txt
     """
 
@@ -3966,6 +3972,7 @@ class NumericalOptionsDescription:
     caching_rtol: FloatDescriptionType = attr.ib(default=1e-2)
     caching_atol: FloatDescriptionType = attr.ib(default=1e-4)
     always_repeat_timestep: bool = attr.ib(default=False, validator=instance_of(bool))
+    damp_slug_flow: bool = attr.ib(default=False, validator=instance_of(bool))
     enable_fast_compositional: bool = attr.ib(default=True, validator=instance_of(bool))
 
 

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -689,6 +689,7 @@ numerical_options_description_schema = Map(
             Str(),
         ),
         Optional("always_repeat_timestep"): Bool(),
+        Optional("damp_slug_flow"): Bool(),
         Optional("enable_fast_compositional"): Bool(),
     }
 )
@@ -2068,4 +2069,4 @@ case_description_schema = Map(
         Optional("multiple_runs"): multiple_runs_description_schema,
     }
 )
-# [[[end]]] (sum: nKADAAI2zz) (sum: CQyFck5z5A) (sum: aeP0PSYoMl) (sum: aeP0PSYoMl) (sum: tXfZ94z3lP) (sum: tXfZ94z3lP)
+# [[[end]]] (sum: 7WvzpdbrZh) (sum: nKADAAI2zz) (sum: CQyFck5z5A) (sum: aeP0PSYoMl) (sum: aeP0PSYoMl) (sum: tXfZ94z3lP) (sum: tXfZ94z3lP)

--- a/tests/alfacase/test_case_to_alfacase/test_convert_case_with_multiple_runs.alfacase
+++ b/tests/alfacase/test_case_to_alfacase/test_convert_case_with_multiple_runs.alfacase
@@ -88,6 +88,7 @@ numerical_options:
   caching_rtol: 0.01
   caching_atol: 0.0001
   always_repeat_timestep: False
+  damp_slug_flow: False
   enable_fast_compositional: True
 plugins: []
 outputs:

--- a/tests/alfacase/test_case_to_alfacase/test_simple_case_with_array_expr.alfacase
+++ b/tests/alfacase/test_case_to_alfacase/test_simple_case_with_array_expr.alfacase
@@ -89,6 +89,7 @@ numerical_options:
   caching_rtol: 0.01
   caching_atol: 0.0001
   always_repeat_timestep: False
+  damp_slug_flow: False
   enable_fast_compositional: True
 plugins: []
 outputs:

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_NumericalOptionsDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_NumericalOptionsDescription_.txt
@@ -18,6 +18,7 @@
             caching_rtol: float | \ :class:`FloatExpression <alfasim_sdk._internal.alfacase.case_description_attributes.FloatExpression>`\  = 0.01
             caching_atol: float | \ :class:`FloatExpression <alfasim_sdk._internal.alfacase.case_description_attributes.FloatExpression>`\  = 0.0001
             always_repeat_timestep: bool = False
+            damp_slug_flow: bool = False
             enable_fast_compositional: bool = True
 
 .. tab:: Schema
@@ -46,4 +47,5 @@
             caching_atol:  # optional
                 number | expr
             always_repeat_timestep: boolean  # optional
+            damp_slug_flow: boolean  # optional
             enable_fast_compositional: boolean  # optional

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -697,6 +697,7 @@ numerical_options_description_schema = Map(
             Str(),
         ),
         Optional("always_repeat_timestep"): Bool(),
+        Optional("damp_slug_flow"): Bool(),
         Optional("enable_fast_compositional"): Bool(),
     }
 )

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -712,6 +712,7 @@ NUMERICAL_OPTIONS_DESCRIPTION = case_description.NumericalOptionsDescription(
     caching_rtol=3e-3,
     caching_atol=4e-4,
     always_repeat_timestep=False,
+    damp_slug_flow=False,
     enable_fast_compositional=True,
 )
 TRACER_MODEL_CONSTANT_COEFFICIENTS_DESCRIPTION = (


### PR DESCRIPTION
## Description
A check box was implemented in the GUI in the numerical options tab to set the boolean `damp_slug_flow`, which activates a damp in the flow pattern transitions involving slug in alfasim_calc.
Then, alfasim-sdk was edited to take this parameter into consideration in the case description and when converting from alfacase.
For mode information on the numerical motivation, check the related PR description.

### Related PR: https://github.com/ESSS/alfasim/pull/1264

- [x] Update CHANGELOG.md

- [x] Remember to squash and/or fix up commits if needed before merging

ASIM-6524