### PR TITLE
Pin the windows runner version to 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
 
     steps:
     - uses: actions/checkout@v2
       with:
         lfs: true
-    - uses: ilammy/msvc-dev-cmd@v1.13.0
+    - uses: ilammy/msvc-dev-cmd@v1
       with:
         vsversion: "2022"
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Pin the 2022 version for windows runners because the most recent runner version does not support the Visual Studio 2022.