### PR TITLE
Add TransientBidimensional to PipeThermalModelType enum

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 1.7.0 (UNRELEASED)
 ==================
 
+* Add TransientBidimensional option to PipeThermalModelType which represents when a 2D mesh will be used to compute wall heat transfer.
+
 1.6.0 (2026-05-18)
 ==================
 

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -56,7 +56,7 @@ from .case_description_attributes import (
 #   cog.out(code)
 #
 # ]]]
-# [[[end]]] (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg)
+# [[[end]]] (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -389,7 +389,7 @@ class _MassSourceCommon:
         default=Curve(Array('temperature', [], 'K'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
+    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
 
     source_type: constants.MassSourceType = attrib_enum(
         default=constants.MassSourceType.MassFlowRates
@@ -409,7 +409,7 @@ class _MassSourceCommon:
         metadata={"type": "curve_dict", "category": 'standard volume per time'},
     )
     # fmt: on
-    # [[[end]]] (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: LHETA/Ml6x)
+    # [[[end]]] (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: LHETA/Ml6x)
 
     # [[[cog
     # cog_out_multi_input_dict("mass_flow_rates", "mass flow rate")
@@ -425,7 +425,7 @@ class _MassSourceCommon:
         metadata={"type": "curve_dict", "category": 'mass flow rate'},
     )
     # fmt: on
-    # [[[end]]] (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP)  (sum: TdUaJF6JS+)
+    # [[[end]]] (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP)  (sum: TdUaJF6JS+)
 
     # [[[cog
     # cog_out_multi_input("total_mass_flow_rate", "mass flow rate", 1.0, "kg/s")
@@ -439,7 +439,7 @@ class _MassSourceCommon:
         default=Curve(Array('mass flow rate', [], 'kg/s'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: z0hwjEu4RX)
+    # [[[end]]] (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: z0hwjEu4RX)
 
     # [[[cog
     # cog_out_multi_input("water_cut", "volume fraction", 0.0, "-")
@@ -453,7 +453,7 @@ class _MassSourceCommon:
         default=Curve(Array('volume fraction', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
+    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
 
     # [[[cog
     # cog_out_multi_input("gas_oil_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -467,7 +467,7 @@ class _MassSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
+    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
 
 
 @attr.s(kw_only=True, auto_attribs=True)
@@ -493,7 +493,7 @@ class _PressureSourceCommon:
         default=Curve(Array('pressure', [], 'Pa'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: /grsrjTChp)
+    # [[[end]]] (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: /grsrjTChp)
 
     # [[[cog
     # cog_out_multi_input("temperature", "temperature", constants.DEFAULT_TEMPERATURE_IN_K, "K")
@@ -507,7 +507,7 @@ class _PressureSourceCommon:
         default=Curve(Array('temperature', [], 'K'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
+    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
 
     fluid: str | None = attr.ib(default=None, validator=optional(instance_of(str)))
 
@@ -535,7 +535,7 @@ class _PressureSourceCommon:
         metadata={"type": "curve_dict", "category": 'mass fraction'},
     )
     # fmt: on
-    # [[[end]]] (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW)  (sum: 3ryMqAbjl3)
+    # [[[end]]] (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW)  (sum: 3ryMqAbjl3)
 
     # [[[cog
     # cog_out_multi_input_dict("volume_fractions", "volume fraction")
@@ -551,7 +551,7 @@ class _PressureSourceCommon:
         metadata={"type": "curve_dict", "category": 'volume fraction'},
     )
     # fmt: on
-    # [[[end]]] (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: rikXFMJhOC)
+    # [[[end]]] (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: rikXFMJhOC)
 
     # [[[cog
     # cog_out_multi_input("gas_liquid_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -565,7 +565,7 @@ class _PressureSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: yzsWkpscA9)
+    # [[[end]]] (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: yzsWkpscA9)
 
     # [[[cog
     # cog_out_multi_input("gas_oil_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -579,7 +579,7 @@ class _PressureSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
+    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
 
     # [[[cog
     # cog_out_multi_input("water_cut", "volume fraction", 0.0, "-")
@@ -593,7 +593,7 @@ class _PressureSourceCommon:
         default=Curve(Array('volume fraction', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
+    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -883,7 +883,7 @@ class PumpEquipmentDescription:
         default=Curve(Array('angle per time', [], 'Hz'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: dxZn8buTyh)
+    # [[[end]]] (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: dxZn8buTyh)
     esp_number_of_stages: int = attr.ib(default=1, validator=instance_of(int))
     esp_reference_density: ScalarDescriptionType = attrib_scalar(
         category="density", default=Scalar(0.0, "kg/m3")
@@ -1037,7 +1037,7 @@ class PigEquipmentDescription:
         default=Curve(Array('mass', [], 'kg'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: BdZkmlPetC)
+    # [[[end]]] (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: BdZkmlPetC)
 
     # [[[cog
     # cog_out_multi_input("static_force", "force", 1000.0, "N")
@@ -1051,7 +1051,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force', [], 'N'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: QJ/kXRt3yB)
+    # [[[end]]] (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: QJ/kXRt3yB)
 
     # [[[cog
     # cog_out_multi_input("wall_friction", "force per velocity", 1000.0, "N.s/m")
@@ -1065,7 +1065,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity', [], 'N.s/m'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: wYu6+BdFjc)
+    # [[[end]]] (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: wYu6+BdFjc)
 
     # [[[cog
     # cog_out_multi_input("linear_friction", "force per velocity", 10.0, "N.s/m")
@@ -1079,7 +1079,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity', [], 'N.s/m'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: 7VUYd0GERZ)
+    # [[[end]]] (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: 7VUYd0GERZ)
 
     # [[[cog
     # cog_out_multi_input("quadratic_friction", "force per velocity squared", 0.0, "N.s2/m2")
@@ -1093,7 +1093,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity squared', [], 'N.s2/m2'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: bS98jFAj/B)
+    # [[[end]]] (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: bS98jFAj/B)
 
     trap_mode: constants.PigTrappingMode = attrib_enum(
         default=constants.PigTrappingMode.Automatic
@@ -1223,7 +1223,7 @@ class LeakEquipmentDescription:
         default=Curve(Array('dimensionless', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: 2rH2wVwV7l)
+    # [[[end]]] (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: 2rH2wVwV7l)
 
     target_pipe_name: str | None = attr.ib(
         default=None, validator=optional(instance_of(str))
@@ -1294,7 +1294,7 @@ class LinearIPRDescription(CommonIPR):
         default=Curve(Array('productivity index', [], 'm3/bar.d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
+    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1322,7 +1322,7 @@ class VogelIPRDescription(CommonIPR):
         default=Curve(Array('standard volume per time', [], 'sm3/d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: BsUYnwfXz2)
+    # [[[end]]] (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: BsUYnwfXz2)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1353,7 +1353,7 @@ class FetkovichIPRDescription(CommonIPR):
         default=Curve(Array('productivity index', [], 'm3/bar.d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
+    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1498,7 +1498,7 @@ class HeatSourceEquipmentDescription:
         default=Curve(Array('power', [], 'W'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: 0l1Sjk5IZu)
+    # [[[end]]] (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: 0l1Sjk5IZu)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -1639,7 +1639,7 @@ controller_node_properties_description_schema = Map(
 )
 environment_description_schema = Map(
     {
-        Optional("thermal_model"): Enum(['adiabatic_walls', 'steady_state_heat_transfer', 'transient_heat_transfer']),
+        Optional("thermal_model"): Enum(['adiabatic_walls', 'steady_state_heat_transfer', 'transient_heat_transfer', 'transient_heat_transfer_bidimensional']),
         Optional("position_input_mode"): Enum(['position_by_tvd', 'position_by_md']),
         Optional("reference_y_coordinate"): UnsafeOrValidator(
             Map({"value": Float(), "unit": Str()}),
@@ -2069,4 +2069,4 @@ case_description_schema = Map(
         Optional("multiple_runs"): multiple_runs_description_schema,
     }
 )
-# [[[end]]] (sum: 7WvzpdbrZh) (sum: nKADAAI2zz) (sum: CQyFck5z5A) (sum: aeP0PSYoMl) (sum: aeP0PSYoMl) (sum: tXfZ94z3lP) (sum: tXfZ94z3lP)
+# [[[end]]] (sum: 7RHTMcNRr1) (sum: 7WvzpdbrZh) (sum: nKADAAI2zz) (sum: CQyFck5z5A) (sum: aeP0PSYoMl) (sum: aeP0PSYoMl) (sum: tXfZ94z3lP) (sum: tXfZ94z3lP)

--- a/src/alfasim_sdk/_internal/constants.py
+++ b/src/alfasim_sdk/_internal/constants.py
@@ -221,6 +221,7 @@ class PipeThermalModelType(Enum):
     AdiabaticWalls = "adiabatic_walls"
     SteadyState = "steady_state_heat_transfer"
     Transient = "transient_heat_transfer"
+    TransientBidimensional = "transient_heat_transfer_bidimensional"
 
 
 class PipeThermalPositionInput(Enum):

--- a/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
+++ b/tests/alfacase/test_generate_case_schema/test_generate_schema_for_all_cases.txt
@@ -1685,7 +1685,7 @@ controller_node_properties_description_schema = Map(
 
 environment_description_schema = Map(
     {
-        Optional("thermal_model"): Enum(['adiabatic_walls', 'steady_state_heat_transfer', 'transient_heat_transfer']),
+        Optional("thermal_model"): Enum(['adiabatic_walls', 'steady_state_heat_transfer', 'transient_heat_transfer', 'transient_heat_transfer_bidimensional']),
         Optional("position_input_mode"): Enum(['position_by_tvd', 'position_by_md']),
         Optional("reference_y_coordinate"): UnsafeOrValidator(
             Map({"value": Float(), "unit": Str()}),


### PR DESCRIPTION
## Description

Add TransientBidimensional option to PipeThermalModelType which represents when a 2D mesh will be used to compute wall heat transfer

## Related Issue(s)
ASIM-6593

## Checklist

- [x] Update CHANGELOG.md
