### PR TITLE
[ASIM-6770] Addition of new category called growth rate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+1.8.0 (UNRELEASED)
+==================
+
+* Add ``growth rate`` category to the unit system, with units of velocity.
+
 1.7.0 (2026-06-26)
 ==================
 

--- a/src/alfasim_sdk/_internal/units.py
+++ b/src/alfasim_sdk/_internal/units.py
@@ -121,6 +121,12 @@ def register_units() -> None:
         "velocity", quantity_type="velocity", valid_units=velocity_units, override=True
     )
 
+    add_category_if_not_defined(
+        category="growth rate",
+        quantity_type="velocity",
+        valid_units=db.GetValidUnits("velocity"),
+    )
+
     # we don't construct volume_per_volume_units using 'volume_units' because the number of units available by
     # the dimensionless quantity type is really small
     volume_per_volume_units = ["m3/m3", "L/m3", "ft3/ft3", "volppm"]


### PR DESCRIPTION
### Motivation
As previously reported, the secondary variable growth rate has been showing negative values in edge group analysis, whereas it shows positive values for individual equipment. It was identified that the issue is caused by the category (velocity) under which this variable is currently classified. This classification treats the variable as a vector, applying a -1 multiplier in certain situations. This task resolves the issue by creating a dedicated category for such variable called ```growth rate```.

### Modifications
- Addition of ```category="growth rate"``` in the  ```alfasim_plugin_scaling``` side in order to avoid the classification of its category as ```velocity```;
- Addition of new ```growth rate``` category in the ```alfasim-sdk``` side;
- Addition of ```mm/a``` as a default unit in the GUI.

### Related Issues(s)
ASIM-6770

## Checklist

- [x] Update CHANGELOG.md
- [ ] Bump the version to `.dev` if there are user facing changes, for example `v1.6.0` -> `v1.7.0.dev`.
