### PR TITLE
[ASIM-6686] Include python version in the generated .hmplugin file name

### DIFF
--- a/src/alfasim_sdk/_internal/alfasim_sdk_utils.py
+++ b/src/alfasim_sdk/_internal/alfasim_sdk_utils.py
@@ -103,3 +103,12 @@ def get_required_python_version() -> str:
     # Assume most plugins will use compiled code and include an upper bound.
     major, minor, *_ = sys.version_info
     return f">={major}.{minor},<{major}.{minor + 1}"
+
+
+def get_current_python_version_tag() -> str:
+    """
+    Return the current python version as a short tag (e.g. "py312"), suitable for inclusion
+    in generated file names. Extracted to be easier to mock in tests.
+    """
+    major, minor, *_ = sys.version_info
+    return f"py{major}{minor}"

--- a/src/alfasim_sdk/default_tasks.py
+++ b/src/alfasim_sdk/default_tasks.py
@@ -230,6 +230,7 @@ def package_only(ctx, package_name="", dst=""):
     hook_specs_file_path = _get_hook_specs_file_path()
     hm = HookManGenerator(hook_spec_file_path=hook_specs_file_path)
     from alfasim_sdk._internal.alfasim_sdk_utils import (
+        get_current_python_version_tag,
         get_current_version,
         get_required_sdk_version,
     )
@@ -237,7 +238,9 @@ def package_only(ctx, package_name="", dst=""):
     plugin_id = str(plugin_dir.name)
     if not package_name:
         package_name = plugin_id
-    package_name_suffix = f"sdk-{get_current_version()}"
+    package_name_suffix = (
+        f"sdk-{get_current_version()}-{get_current_python_version_tag()}"
+    )
     requirements = {
         "alfasim_sdk": get_required_sdk_version(),
         "python": get_required_python_version(),

--- a/tests/test_alfasim_sdk_utils.py
+++ b/tests/test_alfasim_sdk_utils.py
@@ -21,6 +21,14 @@ def test_get_extras_default_required_version(mocker, version, expected):
     assert get_required_sdk_version() == expected
 
 
+def test_get_current_python_version_tag(monkeypatch) -> None:
+    import alfasim_sdk._internal.alfasim_sdk_utils as alfasim_sdk_utils
+    from alfasim_sdk._internal.alfasim_sdk_utils import get_current_python_version_tag
+
+    monkeypatch.setattr(alfasim_sdk_utils.sys, "version_info", (3, 12, 1))
+    assert get_current_python_version_tag() == "py312"
+
+
 def test_get_metadata() -> None:
     from alfasim_sdk import data_model
     from alfasim_sdk._internal.alfasim_sdk_utils import get_metadata

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -8,7 +8,10 @@ from zipfile import ZipFile
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
+from alfasim_sdk._internal.alfasim_sdk_utils import (
+    get_current_python_version_tag,
+    get_current_version,
+)
 
 plugin_id = "acme"
 invoke_cmd = shutil.which("invoke")
@@ -108,11 +111,17 @@ def test_package_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
         ],
     )
 
-    from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
+    from alfasim_sdk._internal.alfasim_sdk_utils import (
+        get_current_python_version_tag,
+        get_current_version,
+    )
 
     os_type = "win" if sys.platform == "win32" else "linux"
     curr_sdk_version = get_current_version()
-    package_filename = Path(f"acme-1.0.0-sdk-{curr_sdk_version}-{os_type}64.hmplugin")
+    curr_python_tag = get_current_python_version_tag()
+    package_filename = Path(
+        f"acme-1.0.0-sdk-{curr_sdk_version}-{curr_python_tag}-{os_type}64.hmplugin"
+    )
     assert package_filename.is_file()
 
 
@@ -130,11 +139,17 @@ def test_package_task_empty_package_name(
         ],
     )
 
-    from alfasim_sdk._internal.alfasim_sdk_utils import get_current_version
+    from alfasim_sdk._internal.alfasim_sdk_utils import (
+        get_current_python_version_tag,
+        get_current_version,
+    )
 
     os_type = "win" if sys.platform == "win32" else "linux"
     curr_sdk_version = get_current_version()
-    package_filename = Path(f"acme-1.0.0-sdk-{curr_sdk_version}-{os_type}64.hmplugin")
+    curr_python_tag = get_current_python_version_tag()
+    package_filename = Path(
+        f"acme-1.0.0-sdk-{curr_sdk_version}-{curr_python_tag}-{os_type}64.hmplugin"
+    )
     assert package_filename.is_file()
 
 
@@ -238,8 +253,9 @@ def create_fake_hmplugin(plugin_dir: Path, monkeypatch: MonkeyPatch) -> Path:
 
     os_type = "win" if sys.platform == "win32" else "linux"
     curr_sdk_version = get_current_version()
+    curr_python_tag = get_current_python_version_tag()
     hmplugin_filename = Path(
-        f"{plugin_id}-1.0.0-sdk-{curr_sdk_version}-{os_type}64.hmplugin"
+        f"{plugin_id}-1.0.0-sdk-{curr_sdk_version}-{curr_python_tag}-{os_type}64.hmplugin"
     )
 
     with ZipFile(hmplugin_filename, "w") as package_file:
@@ -367,8 +383,9 @@ def test_clean_task(new_plugin_dir: Path, monkeypatch: MonkeyPatch):
 
     os_type = "win" if sys.platform == "win32" else "linux"
     curr_sdk_version = get_current_version()
+    curr_python_tag = get_current_python_version_tag()
     hm_plugin_file = Path(
-        f"{plugin_id}-1.0.0-sdk-{curr_sdk_version}-{os_type}64.hmplugin"
+        f"{plugin_id}-1.0.0-sdk-{curr_sdk_version}-{curr_python_tag}-{os_type}64.hmplugin"
     )
     hm_plugin_file.touch()
     assert hm_plugin_file.is_file()


### PR DESCRIPTION

## Description

The file name only included the alfasim-sdk version (e.g. `apb-2026.1.2-sdk-1.5.1-win64.hmplugin`), but the python version it was built against is equally important information for identifying a release artifact.

Adds a Python tag (e.g. "py312"), so generated files now look like `apb-2026.1.2-sdk-1.5.1-py312-win64.hmplugin`.

## Related Issue(s)

ASIM-6686

## Checklist

Not needed, internal.


- ~~[ ] Update CHANGELOG.md~~
- ~~[ ] Bump the version to `.dev` if there are user facing changes, for example `v1.6.0` -> `v1.7.0.dev`.~~
