### PR TITLE
[ASIM-6808] Add get_wall_layer_center_temperature solver API function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ CHANGELOG
 
 * Add ``wall_layer_n_internal_nodes`` attribute to ``EnvironmentDescription``. It refines the radial mesh within each wall layer for the transient wall heat transfer models.
 * Add ``formation_n_layers`` and ``formation_thickness_ratio`` attributes to ``EnvironmentDescription``. They control the discretization of the rock formation surrounding a well for heat transfer purposes.
+* Add ``get_wall_layer_center_temperature`` solver API function. It gets the temperature at the radial center of a wall layer, for a given control volume, using the layer's nearest radial node(s).
 
 1.8.0 (2026-07-17)
 ==================

--- a/docs/source/plugins/99_1_solver_api_reference.rst
+++ b/docs/source/plugins/99_1_solver_api_reference.rst
@@ -171,6 +171,8 @@ ALFAsim's Solver Data
 
 .. doxygenfunction:: get_wall_interfaces_temperature
 
+.. doxygenfunction:: get_wall_layer_center_temperature
+
 .. doxygenfunction:: get_flow_pattern
 
 

--- a/src/alfasim_sdk/alfasim_sdk_api/api.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/api.h
@@ -742,6 +742,26 @@ DLL_EXPORT int get_wall_interfaces_temperature(
 );
 
 /*!
+    Gets the temperature at the radial center of a wall layer, for a given control volume.
+    Returns the exact value of a radial node if the mesh has one at the layer's center,
+    otherwise linearly interpolates between the two nearest radial nodes of that layer.
+
+    @param[in] ctx ALFAsim's plugins context.
+    @param[out] out Wall layer center temperature value.
+    @param[in] control_volume Control Volume ID.
+    @param[in] layer_index Wall layer index (0-based, from inner to outer).
+    @param[in] ts_scope #TimestepScope value.
+    @return An #error_code value.
+*/
+DLL_EXPORT int get_wall_layer_center_temperature(
+    void* ctx,
+    double* out,
+    int control_volume,
+    int layer_index,
+    enum TimestepScope ts_scope
+);
+
+/*!
     Gets the current UCM (unit cell model) input data for friction factor calculation.
     Any available variable by this function is considered for a unit cell, which means
     that there are variables with one value and there are variables with two values

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/api_pointers.h
@@ -74,6 +74,13 @@ using get_wall_interfaces_temperature_func = int (*)(
     enum TimestepScope ts_scope,
     int* size
     );
+using get_wall_layer_center_temperature_func = int (*)(
+    void* ctx,
+    double* out,
+    int control_volume,
+    int layer_index,
+    enum TimestepScope ts_scope
+    );
 using get_wall_properties_func = int (*) (
     void* ctx,
     double** prop_values,
@@ -184,6 +191,7 @@ struct ALFAsimSDK_API {
     get_tracer_partition_coefficient_func get_tracer_partition_coefficient;
 
     get_wall_interfaces_temperature_func get_wall_interfaces_temperature;
+    get_wall_layer_center_temperature_func get_wall_layer_center_temperature;
 
     get_wall_properties_func get_wall_properties;
     set_wall_properties_func set_wall_properties;

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_linux.h
@@ -77,6 +77,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_simulation_tracer_array = (get_simulation_tracer_array_func)dlsym(api->handle, "get_simulation_tracer_array");
     api->get_simulation_quantity = (get_simulation_quantity_func)dlsym(api->handle, "get_simulation_quantity");
     api->get_wall_interfaces_temperature = (get_wall_interfaces_temperature_func)dlsym(api->handle, "get_wall_interfaces_temperature");
+    api->get_wall_layer_center_temperature = (get_wall_layer_center_temperature_func)dlsym(api->handle, "get_wall_layer_center_temperature");
     api->get_wall_properties = (get_wall_properties_func)dlsym(api->handle, "get_wall_properties");
     api->set_wall_properties = (set_wall_properties_func)dlsym(api->handle, "set_wall_properties");
     api->get_wall_material_name = (get_wall_material_name_func)dlsym(api->handle, "get_wall_material_name");

--- a/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
+++ b/src/alfasim_sdk/alfasim_sdk_api/detail/bootstrap_win.h
@@ -101,6 +101,7 @@ inline int alfasim_sdk_open(ALFAsimSDK_API* api)
     api->get_simulation_tracer_array = (get_simulation_tracer_array_func)GetProcAddress(api->handle, "get_simulation_tracer_array");
     api->get_simulation_quantity = (get_simulation_quantity_func)GetProcAddress(api->handle, "get_simulation_quantity");
     api->get_wall_interfaces_temperature = (get_wall_interfaces_temperature_func)GetProcAddress(api->handle, "get_wall_interfaces_temperature");
+    api->get_wall_layer_center_temperature = (get_wall_layer_center_temperature_func)GetProcAddress(api->handle, "get_wall_layer_center_temperature");
     api->get_wall_properties = (get_wall_properties_func)GetProcAddress(api->handle, "get_wall_properties");
     api->set_wall_properties = (set_wall_properties_func)GetProcAddress(api->handle, "set_wall_properties");
     api->get_wall_material_name = (get_wall_material_name_func)GetProcAddress(api->handle, "get_wall_material_name");


### PR DESCRIPTION
ASIM-6808

Adds the alfasim-sdk plumbing needed for the `get_wall_layer_center_temperature` solver API function (added on the alfasim side in commit `9310ad4d79`) to be resolvable by plugins:
