### PR TITLE
Pin cogapp to the exact version used by the GUI/EDEN environment

### DIFF
--- a/docs/source/alfacase/api_reference.rst
+++ b/docs/source/alfacase/api_reference.rst
@@ -18,6 +18,8 @@ Case
 
 .. autoclass:: alfasim_sdk._internal.alfacase.case_description_attributes.FloatExpression()
 
+.. autoclass:: alfasim_sdk._internal.alfacase.case_description_attributes.IntExpression()
+
 .. autoclass:: alfasim_sdk._internal.alfacase.case_description_attributes.ArrayExpression()
 
 .. _alfacase-reference-options-section:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-cogapp
+cogapp==3.3.0  # exact pin: conda-forge (used by EDEN/GUI env) is stuck at 3.3.0, PyPI keeps releasing newer, drifting versions rewrite the generated checksum tags
 colorama
 coverage
 invoke

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -57,7 +57,7 @@ from .case_description_attributes import (
 #   cog.out(code)
 #
 # ]]]
-# [[[end]]] (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg) (sum: 1B2M2Y8Asg)
+# [[[end]]] (checksum: d41d8cd98f00b204e9800998ecf8427e)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -390,7 +390,7 @@ class _MassSourceCommon:
         default=Curve(Array('temperature', [], 'K'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
+    # [[[end]]] (checksum: 707ae01f2d59528c4595e8e25f916295)
 
     source_type: constants.MassSourceType = attrib_enum(
         default=constants.MassSourceType.MassFlowRates
@@ -410,7 +410,7 @@ class _MassSourceCommon:
         metadata={"type": "curve_dict", "category": 'standard volume per time'},
     )
     # fmt: on
-    # [[[end]]] (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: ryPvlsBfAA) (sum: LHETA/Ml6x)
+    # [[[end]]] (checksum: af23ef96c05f0007612cd41c6cf738d7)
 
     # [[[cog
     # cog_out_multi_input_dict("mass_flow_rates", "mass flow rate")
@@ -426,7 +426,7 @@ class _MassSourceCommon:
         metadata={"type": "curve_dict", "category": 'mass flow rate'},
     )
     # fmt: on
-    # [[[end]]] (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP) (sum: Th/dj6mqXP)  (sum: TdUaJF6JS+)
+    # [[[end]]] (checksum: 4e1fdd8fa9aa5cf3ae6b10f3050f69c1)
 
     # [[[cog
     # cog_out_multi_input("total_mass_flow_rate", "mass flow rate", 1.0, "kg/s")
@@ -440,7 +440,7 @@ class _MassSourceCommon:
         default=Curve(Array('mass flow rate', [], 'kg/s'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: bdPklFPWoX) (sum: z0hwjEu4RX)
+    # [[[end]]] (checksum: 6dd3e49453d6a173bdc8b7bebd2bbc38)
 
     # [[[cog
     # cog_out_multi_input("water_cut", "volume fraction", 0.0, "-")
@@ -454,7 +454,7 @@ class _MassSourceCommon:
         default=Curve(Array('volume fraction', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
+    # [[[end]]] (checksum: 53609e0b45bf46a5aaf61afaf695d4ea)
 
     # [[[cog
     # cog_out_multi_input("gas_oil_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -468,7 +468,7 @@ class _MassSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
+    # [[[end]]] (checksum: 437a943db2f8976e463c22301c8e0f4b)
 
 
 @attr.s(kw_only=True, auto_attribs=True)
@@ -494,7 +494,7 @@ class _PressureSourceCommon:
         default=Curve(Array('pressure', [], 'Pa'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: NgSGOwktFe) (sum: /grsrjTChp)
+    # [[[end]]] (checksum: 3604863b092d15ef9ecbb62fede69c77)
 
     # [[[cog
     # cog_out_multi_input("temperature", "temperature", constants.DEFAULT_TEMPERATURE_IN_K, "K")
@@ -508,7 +508,7 @@ class _PressureSourceCommon:
         default=Curve(Array('temperature', [], 'K'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: cHrgHy1ZUo) (sum: Nu7J18/uyl)
+    # [[[end]]] (checksum: 707ae01f2d59528c4595e8e25f916295)
 
     fluid: str | None = attr.ib(default=None, validator=optional(instance_of(str)))
 
@@ -536,7 +536,7 @@ class _PressureSourceCommon:
         metadata={"type": "curve_dict", "category": 'mass fraction'},
     )
     # fmt: on
-    # [[[end]]] (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW) (sum: xh4XHDXoAW)  (sum: 3ryMqAbjl3)
+    # [[[end]]] (checksum: c61e171c35e80169c1fd903803ad4d96)
 
     # [[[cog
     # cog_out_multi_input_dict("volume_fractions", "volume fraction")
@@ -552,7 +552,7 @@ class _PressureSourceCommon:
         metadata={"type": "curve_dict", "category": 'volume fraction'},
     )
     # fmt: on
-    # [[[end]]] (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: YoWQpGvjkl) (sum: rikXFMJhOC)
+    # [[[end]]] (checksum: 628590a46be39251974265f755662d3f)
 
     # [[[cog
     # cog_out_multi_input("gas_liquid_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -566,7 +566,7 @@ class _PressureSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: 7z7g1W75CY) (sum: yzsWkpscA9)
+    # [[[end]]] (checksum: ef3ee0d56ef9098755c542250aa956cb)
 
     # [[[cog
     # cog_out_multi_input("gas_oil_ratio", "standard volume per standard volume", 0.0, "sm3/sm3")
@@ -580,7 +580,7 @@ class _PressureSourceCommon:
         default=Curve(Array('standard volume per standard volume', [], 'sm3/sm3'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: Q3qUPbL4l2) (sum: SvK32WGNil)
+    # [[[end]]] (checksum: 437a943db2f8976e463c22301c8e0f4b)
 
     # [[[cog
     # cog_out_multi_input("water_cut", "volume fraction", 0.0, "-")
@@ -594,7 +594,7 @@ class _PressureSourceCommon:
         default=Curve(Array('volume fraction', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: U2CeC0W/Rq) (sum: 5Lrwey+Qot)
+    # [[[end]]] (checksum: 53609e0b45bf46a5aaf61afaf695d4ea)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -884,7 +884,7 @@ class PumpEquipmentDescription:
         default=Curve(Array('angle per time', [], 'Hz'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: MzC/LIkTUk) (sum: dxZn8buTyh)
+    # [[[end]]] (checksum: 3330bf2c8913524c6628ce98592057ac)
     esp_number_of_stages: int = attr.ib(default=1, validator=instance_of(int))
     esp_reference_density: ScalarDescriptionType = attrib_scalar(
         category="density", default=Scalar(0.0, "kg/m3")
@@ -1038,7 +1038,7 @@ class PigEquipmentDescription:
         default=Curve(Array('mass', [], 'kg'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: jyMN6kwl5z) (sum: BdZkmlPetC)
+    # [[[end]]] (checksum: 8f230dea4c25e73a7241b001a0d616c5)
 
     # [[[cog
     # cog_out_multi_input("static_force", "force", 1000.0, "N")
@@ -1052,7 +1052,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force', [], 'N'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: W+n+agBmMf) (sum: QJ/kXRt3yB)
+    # [[[end]]] (checksum: 5be9fe6a006631f898a938b6144f17c0)
 
     # [[[cog
     # cog_out_multi_input("wall_friction", "force per velocity", 1000.0, "N.s/m")
@@ -1066,7 +1066,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity', [], 'N.s/m'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: LUZ/5RcPa2) (sum: wYu6+BdFjc)
+    # [[[end]]] (checksum: 2d467fe5170f6b612e85d2d7697ffa39)
 
     # [[[cog
     # cog_out_multi_input("linear_friction", "force per velocity", 10.0, "N.s/m")
@@ -1080,7 +1080,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity', [], 'N.s/m'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: jGqpTcorqS) (sum: 7VUYd0GERZ)
+    # [[[end]]] (checksum: 8c6aa94dca2ba92604b895ad732c8805)
 
     # [[[cog
     # cog_out_multi_input("quadratic_friction", "force per velocity squared", 0.0, "N.s2/m2")
@@ -1094,7 +1094,7 @@ class PigEquipmentDescription:
         default=Curve(Array('force per velocity squared', [], 'N.s2/m2'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: wN7wzqbhWp) (sum: bS98jFAj/B)
+    # [[[end]]] (checksum: c0def0cea6e15a916eb134d0b8cb0938)
 
     trap_mode: constants.PigTrappingMode = attrib_enum(
         default=constants.PigTrappingMode.Automatic
@@ -1224,7 +1224,7 @@ class LeakEquipmentDescription:
         default=Curve(Array('dimensionless', [], '-'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: AOfhRguJ6N) (sum: 2rH2wVwV7l)
+    # [[[end]]] (checksum: 00e7e1460b89e8da38d5506d7ace188a)
 
     target_pipe_name: str | None = attr.ib(
         default=None, validator=optional(instance_of(str))
@@ -1295,7 +1295,7 @@ class LinearIPRDescription(CommonIPR):
         default=Curve(Array('productivity index', [], 'm3/bar.d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
+    # [[[end]]] (checksum: f9b27bcce53cda44e6016aae8ae4310a)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1323,7 +1323,7 @@ class VogelIPRDescription(CommonIPR):
         default=Curve(Array('standard volume per time', [], 'sm3/d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: 09Us5imZlH) (sum: BsUYnwfXz2)
+    # [[[end]]] (checksum: d3d52ce629999478d7a8aa9ed7fc1c51)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1354,7 +1354,7 @@ class FetkovichIPRDescription(CommonIPR):
         default=Curve(Array('productivity index', [], 'm3/bar.d'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: +bJ7zOU82k) (sum: r3U12R+7CY)
+    # [[[end]]] (checksum: f9b27bcce53cda44e6016aae8ae4310a)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)
@@ -1499,7 +1499,7 @@ class HeatSourceEquipmentDescription:
         default=Curve(Array('power', [], 'W'), Array('time', [], 's'))
     )
     # fmt: on
-    # [[[end]]] (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: HC8YUfkVYj) (sum: 0l1Sjk5IZu)
+    # [[[end]]] (checksum: 1c2f1851f9156238464f93070019929c)
 
 
 @attr.s(frozen=True, slots=True, auto_attribs=True)

--- a/src/alfasim_sdk/_internal/alfacase/schema.py
+++ b/src/alfasim_sdk/_internal/alfacase/schema.py
@@ -2081,4 +2081,4 @@ case_description_schema = Map(
         Optional("multiple_runs"): multiple_runs_description_schema,
     }
 )
-# [[[end]]] (sum: gpiXiYjGjz) (sum: oec1+mvW48) (sum: 7RHTMcNRr1) (sum: 7WvzpdbrZh) (sum: nKADAAI2zz) (sum: CQyFck5z5A) (sum: aeP0PSYoMl) (sum: aeP0PSYoMl) (sum: tXfZ94z3lP) (sum: tXfZ94z3lP)
+# [[[end]]] (checksum: 8298978988c68f32d91f8196c15088dc)


### PR DESCRIPTION
requirements_dev.txt left cogapp unpinned, so tox/CI resolved the newest PyPI release (3.6.0) while the GUI env (EDEN/conda-forge) is stuck at 3.3.0. The two versions write different checksum-tag formats, causing spurious diffs when cogging under different environments.

Pin to 3.3.0 to match conda-forge, and regenerate the cogged files under that version, cleaning up stale tags left by newer cogapp releases.
