### PR TITLE
[ASIM-6850] Add dedicated roughness unit category

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 1.10.0 (UNRELEASED)
 ==================
 
+* Add ``roughness`` category to the unit system, with a curated set of units (``m``, ``mm``, ``cm``, ``um`` and ``in``) more appropriate for roughness magnitudes than the full ``length`` unit list. ``inner_roughness`` (in ``CasingSectionDescription``, ``TubingDescription``, ``OpenHoleDescription`` and ``WallDescription``) and ``roughnesses`` (in ``PipeSegmentsDescription``) now use this category instead of ``length``.
+
 1.9.0 (2026-08-28)
 ==================
 

--- a/docs/source/alfacase_definitions/WallDescription.txt
+++ b/docs/source/alfacase_definitions/WallDescription.txt
@@ -6,7 +6,7 @@
 
         class WallDescription
             name: str
-            inner_roughness: \ :class:`Scalar <barril.units.Scalar>`\ | \ :class:`ScalarExpression <alfasim_sdk._internal.alfacase.case_description_attributes.ScalarExpression>`\  = Scalar(0.0, 'm', 'length')
+            inner_roughness: \ :class:`Scalar <barril.units.Scalar>`\ | \ :class:`ScalarExpression <alfasim_sdk._internal.alfacase.case_description_attributes.ScalarExpression>`\  = Scalar(0.0, 'm', 'roughness')
             wall_layer_container: \ :class:`List <typing.List>`\[\ :class:`WallLayerDescription <WallLayerDescription>`\] = []
 
 .. tab:: Schema

--- a/docs/source/alfacase_definitions/list_of_unit_for_roughness.txt
+++ b/docs/source/alfacase_definitions/list_of_unit_for_roughness.txt
@@ -1,0 +1,8 @@
+.. admonition:: Available units for category 'roughness'
+    :class: dropdown
+
+    :"cm": centimetre
+    :"in": inch
+    :"m": metre
+    :"mm": millimetres
+    :"um": microns

--- a/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
+++ b/src/alfasim_sdk/_internal/alfacase/alfacase_to_case.py
@@ -854,7 +854,7 @@ def load_casing_section_description(
         "hole_diameter": get_scalar_loader(category="diameter"),
         "outer_diameter": get_scalar_loader(category="diameter"),
         "inner_diameter": get_scalar_loader(category="diameter"),
-        "inner_roughness": get_scalar_loader(from_unit="m"),
+        "inner_roughness": get_scalar_loader(category="roughness"),
         "material": load_value,
         "top_of_filler": get_scalar_loader(from_unit="m"),
         "filler_material": load_value,
@@ -1344,7 +1344,7 @@ def load_pipe_segments_description(
     alfacase_to_case_description: dict[str, Any] = {
         "start_positions": get_array_loader(from_unit="m"),
         "diameters": get_array_loader(from_unit="m"),
-        "roughnesses": get_array_loader(from_unit="m"),
+        "roughnesses": get_array_loader(category="roughness"),
         "wall_names": load_value,
     }
     case_values = to_case_values(document, alfacase_to_case_description)
@@ -1650,7 +1650,7 @@ def load_tubing_description(
         "length": get_scalar_loader(from_unit="m"),
         "outer_diameter": get_scalar_loader(category="diameter"),
         "inner_diameter": get_scalar_loader(category="diameter"),
-        "inner_roughness": get_scalar_loader(from_unit="m"),
+        "inner_roughness": get_scalar_loader(category="roughness"),
         "material": load_value,
     }
 
@@ -1731,7 +1731,7 @@ def load_open_hole_description(
         "name": load_value,
         "length": get_scalar_loader(from_unit="m"),
         "diameter": get_scalar_loader(category="diameter"),
-        "inner_roughness": get_scalar_loader(from_unit="m"),
+        "inner_roughness": get_scalar_loader(category="roughness"),
     }
 
     def generate_open_hole_description(document: DescriptionDocument):
@@ -1889,7 +1889,7 @@ def load_wall_description(
 ) -> list[case_description.WallDescription]:
     alfacase_to_case_description: dict[str, Any] = {
         "name": load_value,
-        "inner_roughness": get_scalar_loader(from_unit="m"),
+        "inner_roughness": get_scalar_loader(category="roughness"),
         "wall_layer_container": load_wall_layer_description,
     }
 

--- a/src/alfasim_sdk/_internal/alfacase/case_description.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description.py
@@ -1509,6 +1509,7 @@ class PipeSegmentsDescription:
 
     .. include:: /alfacase_definitions/list_of_unit_for_length.txt
 
+    .. include:: /alfacase_definitions/list_of_unit_for_roughness.txt
     """
 
     start_positions: ArrayDescriptionType | None = attr.ib(
@@ -2314,6 +2315,8 @@ class CasingSectionDescription:
     .. include:: /alfacase_definitions/CasingSectionDescription.txt
 
     .. include:: /alfacase_definitions/list_of_unit_for_length.txt
+
+    .. include:: /alfacase_definitions/list_of_unit_for_roughness.txt
     """
 
     name: str = attr.ib(validator=instance_of(str))
@@ -2322,7 +2325,7 @@ class CasingSectionDescription:
     hole_diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
     outer_diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
     inner_diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
-    inner_roughness: ScalarDescriptionType = attrib_scalar(category="length")
+    inner_roughness: ScalarDescriptionType = attrib_scalar(category="roughness")
     material: str | None = attr.ib(default=None, validator=optional(instance_of(str)))
     top_of_filler: ScalarDescriptionType = attrib_scalar(category="length")
     filler_material: str | None = attr.ib(
@@ -2347,13 +2350,15 @@ class TubingDescription:
     .. include:: /alfacase_definitions/TubingDescription.txt
 
     .. include:: /alfacase_definitions/list_of_unit_for_length.txt
+
+    .. include:: /alfacase_definitions/list_of_unit_for_roughness.txt
     """
 
     name: str = attr.ib(validator=instance_of(str))
     length: ScalarDescriptionType = attrib_scalar(category="length")
     outer_diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
     inner_diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
-    inner_roughness: ScalarDescriptionType = attrib_scalar(category="length")
+    inner_roughness: ScalarDescriptionType = attrib_scalar(category="roughness")
     material: str | None = attr.ib(default=None, validator=optional(instance_of(str)))
 
     @outer_diameter.validator
@@ -2385,12 +2390,14 @@ class OpenHoleDescription:
     .. include:: /alfacase_definitions/OpenHoleDescription.txt
 
     .. include:: /alfacase_definitions/list_of_unit_for_length.txt
+
+    .. include:: /alfacase_definitions/list_of_unit_for_roughness.txt
     """
 
     name: str = attr.ib(validator=instance_of(str))
     length: ScalarDescriptionType = attrib_scalar(category="length")
     diameter: ScalarDescriptionType = attrib_scalar(category="diameter")
-    inner_roughness: ScalarDescriptionType = attrib_scalar(category="length")
+    inner_roughness: ScalarDescriptionType = attrib_scalar(category="roughness")
 
     @diameter.validator
     def _validate_diameter(self, attribute, value):
@@ -2565,11 +2572,13 @@ class WallDescription:
     """
     .. include:: /alfacase_definitions/WallDescription.txt
 
-    .. include:: /alfacase_definitions/list_of_unit_for_length.txt
+    .. include:: /alfacase_definitions/list_of_unit_for_roughness.txt
     """
 
     name: str = attr.ib(validator=instance_of(str))
-    inner_roughness: ScalarDescriptionType = attrib_scalar(default=Scalar(0, "m"))
+    inner_roughness: ScalarDescriptionType = attrib_scalar(
+        default=Scalar("roughness", 0, "m")
+    )
     wall_layer_container: list[WallLayerDescription] = attrib_instance_list(
         WallLayerDescription
     )

--- a/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
+++ b/src/alfasim_sdk/_internal/alfacase/case_description_attributes.py
@@ -434,7 +434,6 @@ def attrib_array(
 
     :param category:
         Name of the array category.
-
     """
     if isinstance(default, Array):
         if category is None:

--- a/src/alfasim_sdk/_internal/alfacase/generate_case_description_docstring.py
+++ b/src/alfasim_sdk/_internal/alfacase/generate_case_description_docstring.py
@@ -69,6 +69,7 @@ CATEGORIES_USED_ON_DESCRIPTION = sorted(
         "power",
         "pressure",
         "productivity index",
+        "roughness",
         "specific energy",
         "specific heat capacity",
         "standard volume per standard volume",

--- a/src/alfasim_sdk/_internal/units.py
+++ b/src/alfasim_sdk/_internal/units.py
@@ -42,6 +42,12 @@ def register_units() -> None:
         "length", quantity_type="length", valid_units=length_units, override=True
     )
 
+    add_category_if_not_defined(
+        category="roughness",
+        quantity_type="length",
+        valid_units=["m", "mm", "cm", "um", "in"],
+    )
+
     pressure_units = ["bar", "Pa", "kPa", "MPa", "psi", "kgf/cm2", "atm"]
     db.AddCategory(
         "pressure", quantity_type="pressure", valid_units=pressure_units, override=True

--- a/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_WallDescription_.txt
+++ b/tests/alfacase/test_generate_case_description_docstring/test_generate_case_description_docstring_WallDescription_.txt
@@ -6,7 +6,7 @@
 
         class WallDescription
             name: str
-            inner_roughness: \ :class:`Scalar <barril.units.Scalar>`\ | \ :class:`ScalarExpression <alfasim_sdk._internal.alfacase.case_description_attributes.ScalarExpression>`\  = Scalar(0.0, 'm', 'length')
+            inner_roughness: \ :class:`Scalar <barril.units.Scalar>`\ | \ :class:`ScalarExpression <alfasim_sdk._internal.alfacase.case_description_attributes.ScalarExpression>`\  = Scalar(0.0, 'm', 'roughness')
             wall_layer_container: \ :class:`List <typing.List>`\[\ :class:`WallLayerDescription <WallLayerDescription>`\] = []
 
 .. tab:: Schema

--- a/tests/alfacase/test_generate_list_of_units/test_generate_list_of_units_roughness_.txt
+++ b/tests/alfacase/test_generate_list_of_units/test_generate_list_of_units_roughness_.txt
@@ -1,0 +1,8 @@
+.. admonition:: Available units for category 'roughness'
+    :class: dropdown
+
+    :"cm": centimetre
+    :"in": inch
+    :"m": metre
+    :"mm": millimetres
+    :"um": microns

--- a/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/case_builders.py
@@ -14,7 +14,7 @@ def build_simple_segment():
     return case_description.PipeSegmentsDescription(
         start_positions=Array([0.0], "m"),
         diameters=Array([0.1], "m"),
-        roughnesses=Array([1e-5], "m"),
+        roughnesses=Array("roughness", [1e-5], "m"),
     )
 
 

--- a/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
+++ b/tests/common_testing/alfasim_sdk_common_testing/filled_case_descriptions.py
@@ -147,7 +147,7 @@ CASING_SECTION_DESCRIPTION = case_description.CasingSectionDescription(
     hole_diameter=Scalar("diameter", 2.0, "m"),
     outer_diameter=Scalar("diameter", 0.65, "m"),
     inner_diameter=Scalar("diameter", 0.6, "m"),
-    inner_roughness=Scalar(0.0, "m"),
+    inner_roughness=Scalar("roughness", 0.0, "m"),
     material="Carbon Steel",
     top_of_filler=Scalar(0.0, "m"),
     filler_material="Cement",
@@ -335,12 +335,12 @@ OPEN_HOLE_DESCRIPTION = case_description.OpenHoleDescription(
     name="Open Hole 1",
     length=Scalar(101.0, "m"),
     diameter=Scalar("diameter", 102.0, "m"),
-    inner_roughness=Scalar(103.0, "m"),
+    inner_roughness=Scalar("roughness", 103.0, "m"),
 )
 PIPE_WALL_DESCRIPTION = case_description.PipeSegmentsDescription(
     start_positions=Array([0.0, 300.0], "m"),
     diameters=Array([0.1, 0.1], "m"),
-    roughnesses=Array([1e-5, 1e-5], "m"),
+    roughnesses=Array("roughness", [1e-5, 1e-5], "m"),
     wall_names=["Riser", "Flowline"],
 )
 PROFILE_OUTPUT_DESCRIPTION = case_description.ProfileOutputDescription(
@@ -475,7 +475,7 @@ TUBING_DESCRIPTION = case_description.TubingDescription(
     length=Scalar(42, "m"),
     outer_diameter=Scalar("diameter", 0.35, "m"),
     inner_diameter=Scalar("diameter", 0.3, "m"),
-    inner_roughness=Scalar(0.0, "m"),
+    inner_roughness=Scalar("roughness", 0.0, "m"),
     material="Carbon Steel",
 )
 WALL_LAYER_DESCRIPTION = case_description.WallLayerDescription(
@@ -563,7 +563,7 @@ VALVE_DESCRIPTION_CONSTANT_OPENING = case_description.ValveEquipmentDescription(
 )
 WALL_DESCRIPTION = case_description.WallDescription(
     name="Flowline",
-    inner_roughness=Scalar(1, "mm"),
+    inner_roughness=Scalar("roughness", 1, "mm"),
     wall_layer_container=[WALL_LAYER_DESCRIPTION, WALL_LAYER_DESCRIPTION],
 )
 LEAK_EQUIPMENT_DESCRIPTION = case_description.LeakEquipmentDescription(


### PR DESCRIPTION
Pipe/wall roughness (absolute roughness) was registered under the generic length category, sharing its full unit list even though roughness magnitudes are typically um-mm, much smaller than other length inputs.

Register a roughness category reusing length's dimension/conversions, with a curated unit list (m, mm, cm, um, in). Retag the case description schema and alfacase loaders for the CasingSection/Tubing/ OpenHole/Wall/PipeSegments roughness fields from length to roughness, and update fixtures/regression snapshots accordingly.

